### PR TITLE
Fix drift scan reliability, sensitive data exposure, and cross-platform output

### DIFF
--- a/src/driftsentry/cli/scan.py
+++ b/src/driftsentry/cli/scan.py
@@ -21,12 +21,32 @@ console = Console()
 
 # ─── Shared state for passing scan results to report/remediate ──
 
+LAST_SCAN_FILENAME = ".driftsentry-last-scan.json"
 _last_scan_result: DriftResult | None = None
 
 
 def get_last_scan_result() -> DriftResult | None:
     """Get the result of the last scan (used by report and remediate commands)."""
-    return _last_scan_result
+    if _last_scan_result is not None:
+        return _last_scan_result
+
+    last_scan_path = Path.cwd() / LAST_SCAN_FILENAME
+    if not last_scan_path.exists():
+        return None
+
+    try:
+        return DriftResult.model_validate_json(last_scan_path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _save_last_scan_result(result: DriftResult) -> None:
+    """Persist the latest result so separate CLI invocations can reuse it."""
+    last_scan_path = Path.cwd() / LAST_SCAN_FILENAME
+    last_scan_path.write_text(
+        json.dumps(result.model_dump(mode="json"), indent=2, default=str),
+        encoding="utf-8",
+    )
 
 
 def scan(
@@ -200,6 +220,7 @@ def scan(
 
     # Store for report/remediate commands
     _last_scan_result = result
+    _save_last_scan_result(result)
 
     # Output
     if output_format == "json":
@@ -213,7 +234,10 @@ def scan(
     if save_result:
         save_path = Path(save_result)
         save_path.parent.mkdir(parents=True, exist_ok=True)
-        save_path.write_text(json.dumps(result.model_dump(mode="json"), indent=2, default=str))
+        save_path.write_text(
+            json.dumps(result.model_dump(mode="json"), indent=2, default=str),
+            encoding="utf-8",
+        )
         console.print(f"\n[dim]Result saved to {save_result}[/]")
 
     # Exit code based on drift

--- a/src/driftsentry/core/differ.py
+++ b/src/driftsentry/core/differ.py
@@ -91,7 +91,11 @@ class DriftDiffer:
             return None
 
         # Convert deepdiff output to AttributeDiff objects
-        attr_diffs = self._extract_attribute_diffs(diff, state_resource.resource_type)
+        attr_diffs = self._extract_attribute_diffs(
+            diff,
+            state_resource.resource_type,
+            state_resource.sensitive_attributes,
+        )
 
         if not attr_diffs:
             return None
@@ -166,21 +170,24 @@ class DriftDiffer:
         self,
         diff: DeepDiff,
         resource_type: str,
+        sensitive_attributes: list[str] | None = None,
     ) -> list[AttributeDiff]:
         """Convert DeepDiff output into a list of AttributeDiff objects."""
         diffs: list[AttributeDiff] = []
+        sensitive = sensitive_attributes or []
 
         # Values changed
         for path, change in diff.get("values_changed", {}).items():
             attr_path = self._deepdiff_path_to_dot(path)
             if self._should_ignore_path(attr_path):
                 continue
+            is_sensitive = self._is_sensitive_path(attr_path, sensitive)
             diffs.append(
                 AttributeDiff(
                     path=attr_path,
-                    desired_value=change.get("old_value"),
-                    actual_value=change.get("new_value"),
-                    is_sensitive=False,
+                    desired_value="[REDACTED]" if is_sensitive else change.get("old_value"),
+                    actual_value="[REDACTED]" if is_sensitive else change.get("new_value"),
+                    is_sensitive=is_sensitive,
                 )
             )
 
@@ -189,11 +196,13 @@ class DriftDiffer:
             attr_path = self._deepdiff_path_to_dot(path)
             if self._should_ignore_path(attr_path):
                 continue
+            is_sensitive = self._is_sensitive_path(attr_path, sensitive)
             diffs.append(
                 AttributeDiff(
                     path=attr_path,
-                    desired_value=None,
-                    actual_value=value,
+                    desired_value="[REDACTED]" if is_sensitive else None,
+                    actual_value="[REDACTED]" if is_sensitive else value,
+                    is_sensitive=is_sensitive,
                 )
             )
 
@@ -202,11 +211,13 @@ class DriftDiffer:
             attr_path = self._deepdiff_path_to_dot(path)
             if self._should_ignore_path(attr_path):
                 continue
+            is_sensitive = self._is_sensitive_path(attr_path, sensitive)
             diffs.append(
                 AttributeDiff(
                     path=attr_path,
-                    desired_value=value,
-                    actual_value=None,
+                    desired_value="[REDACTED]" if is_sensitive else value,
+                    actual_value="[REDACTED]" if is_sensitive else None,
+                    is_sensitive=is_sensitive,
                 )
             )
 
@@ -215,11 +226,13 @@ class DriftDiffer:
             attr_path = self._deepdiff_path_to_dot(path)
             if self._should_ignore_path(attr_path):
                 continue
+            is_sensitive = self._is_sensitive_path(attr_path, sensitive)
             diffs.append(
                 AttributeDiff(
                     path=attr_path,
-                    desired_value=change.get("old_value"),
-                    actual_value=change.get("new_value"),
+                    desired_value="[REDACTED]" if is_sensitive else change.get("old_value"),
+                    actual_value="[REDACTED]" if is_sensitive else change.get("new_value"),
+                    is_sensitive=is_sensitive,
                 )
             )
 
@@ -229,11 +242,21 @@ class DriftDiffer:
                 attr_path = self._deepdiff_path_to_dot(path)
                 if self._should_ignore_path(attr_path):
                     continue
+                is_sensitive = self._is_sensitive_path(attr_path, sensitive)
                 diffs.append(
                     AttributeDiff(
                         path=attr_path,
-                        desired_value=value if diff_type == "iterable_item_removed" else None,
-                        actual_value=value if diff_type == "iterable_item_added" else None,
+                        desired_value=(
+                            "[REDACTED]"
+                            if is_sensitive
+                            else value if diff_type == "iterable_item_removed" else None
+                        ),
+                        actual_value=(
+                            "[REDACTED]"
+                            if is_sensitive
+                            else value if diff_type == "iterable_item_added" else None
+                        ),
+                        is_sensitive=is_sensitive,
                     )
                 )
 
@@ -267,6 +290,11 @@ class DriftDiffer:
         """Check if an attribute path should be ignored."""
         top_level = path.split(".")[0]
         return top_level in self._ignore
+
+    @staticmethod
+    def _is_sensitive_path(path: str, sensitive_attributes: list[str]) -> bool:
+        """Check whether a diff path is a sensitive state attribute or child path."""
+        return any(path == sensitive or path.startswith(f"{sensitive}.") for sensitive in sensitive_attributes)
 
     @staticmethod
     def _deepdiff_path_to_dot(path: str) -> str:

--- a/src/driftsentry/core/scanner.py
+++ b/src/driftsentry/core/scanner.py
@@ -198,7 +198,7 @@ class DriftScanner:
             except Exception as e:
                 errors.append(f"Error scanning {rtype}: {e}")
                 logger.error(f"Error scanning {rtype}: {e}")
-                cloud_resources[rtype] = []
+                # Do not add a failed type: missing results must not look deleted.
 
         return cloud_resources
 

--- a/src/driftsentry/llm/claude_provider.py
+++ b/src/driftsentry/llm/claude_provider.py
@@ -22,7 +22,7 @@ class ClaudeProvider(BaseLLMProvider):
 
     def __init__(self, config: LLMConfig | None = None) -> None:
         try:
-            import anthropic  # type: ignore[import-not-found]
+            import anthropic
         except ImportError as exc:
             raise ImportError(
                 "The 'anthropic' package is required for Claude AI features. "

--- a/src/driftsentry/llm/gemini_provider.py
+++ b/src/driftsentry/llm/gemini_provider.py
@@ -22,8 +22,8 @@ class GeminiProvider(BaseLLMProvider):
 
     def __init__(self, config: LLMConfig | None = None) -> None:
         try:
-            from google import genai  # type: ignore[import-not-found]
-            from google.genai import (  # type: ignore[import-not-found]
+            from google import genai
+            from google.genai import (
                 types as genai_types,
             )
         except ImportError as exc:

--- a/src/driftsentry/output/json_fmt.py
+++ b/src/driftsentry/output/json_fmt.py
@@ -26,6 +26,7 @@ class JSONFormatter:
             The JSON string.
         """
         data = result.model_dump(mode="json")
+        self._redact_sensitive_resources(data)
         indent = 2 if self.pretty else None
         json_str = json.dumps(data, indent=indent, default=str, sort_keys=False)
 
@@ -37,3 +38,54 @@ class JSONFormatter:
             sys.stdout.write("\n")
 
         return json_str
+
+    @staticmethod
+    def _redact_sensitive_resources(data: dict[str, object]) -> None:
+        """Redact sensitive state paths before emitting machine-readable output."""
+        drift_items = data.get("drift_items")
+        if not isinstance(drift_items, list):
+            return
+
+        for item in drift_items:
+            if not isinstance(item, dict):
+                continue
+            state_resource = item.get("state_resource")
+            if not isinstance(state_resource, dict):
+                continue
+            sensitive = state_resource.get("sensitive_attributes", [])
+            attributes = state_resource.get("attributes")
+            if not isinstance(sensitive, list) or not isinstance(attributes, dict):
+                continue
+            for path in sensitive:
+                if isinstance(path, str):
+                    JSONFormatter._redact_path(attributes, path.split("."))
+
+            cloud_resource = item.get("cloud_resource")
+            if isinstance(cloud_resource, dict) and isinstance(cloud_resource.get("attributes"), dict):
+                for path in sensitive:
+                    if isinstance(path, str):
+                        JSONFormatter._redact_path(
+                            cloud_resource["attributes"], path.split(".")
+                        )
+
+    @staticmethod
+    def _redact_path(attributes: dict[str, object], path: list[str]) -> None:
+        """Replace a nested attribute value with a non-sensitive marker."""
+        current: object = attributes
+        for part in path[:-1]:
+            if isinstance(current, dict):
+                current = current.get(part)
+            elif isinstance(current, list) and part.isdigit():
+                index = int(part)
+                current = current[index] if index < len(current) else None
+            else:
+                return
+        if not path:
+            return
+        final = path[-1]
+        if isinstance(current, dict) and final in current:
+            current[final] = "[REDACTED]"
+        elif isinstance(current, list) and final.isdigit():
+            index = int(final)
+            if index < len(current):
+                current[index] = "[REDACTED]"

--- a/src/driftsentry/providers/aws/declarative.py
+++ b/src/driftsentry/providers/aws/declarative.py
@@ -51,7 +51,7 @@ class GenericAWSDeclarativeScanner(ResourceScanner):
             logger.warning(
                 f"Failed to list {self.spec.terraform_type} via {disc.list_operation}: {e}"
             )
-            return []
+            raise
 
         for item in raw_items:
             try:
@@ -92,6 +92,7 @@ class GenericAWSDeclarativeScanner(ResourceScanner):
                 )
             except Exception as e:
                 logger.debug(f"Error processing {self.spec.terraform_type} item: {e}")
+                raise
 
         return resources
 

--- a/src/driftsentry/providers/aws/provider.py
+++ b/src/driftsentry/providers/aws/provider.py
@@ -68,7 +68,7 @@ class AWSProvider(CloudProvider):
             return scanner.list_all()
         except Exception as e:
             logger.error(f"Error scanning {resource_type}: {e}")
-            return []
+            raise
 
     def get_resource(self, resource_type: str, resource_id: str) -> CloudResource | None:
         """Get a specific AWS resource by its ID."""

--- a/src/driftsentry/remediation/generator.py
+++ b/src/driftsentry/remediation/generator.py
@@ -163,7 +163,7 @@ class RemediationGenerator:
         if not self._dry_run:
             # Write import script
             import_file = self._output_dir / "import.sh"
-            with open(import_file, "a") as f:
+            with open(import_file, "a", encoding="utf-8") as f:
                 f.write(f"# Import {item.resource_type} — {resource_id}\n")
                 f.write(f"{import_cmd}\n\n")
             import_file.chmod(0o755)
@@ -171,7 +171,7 @@ class RemediationGenerator:
 
             # Write HCL
             hcl_file = self._output_dir / f"imported_{suggested_name}.tf"
-            with open(hcl_file, "w") as f:
+            with open(hcl_file, "w", encoding="utf-8") as f:
                 f.write(hcl_block)
             output.files_created.add(str(hcl_file))
 
@@ -212,14 +212,17 @@ class RemediationGenerator:
             revert_file = self._output_dir / "revert_plan.json"
             existing: list[dict[str, Any]] = []
             if revert_file.exists():
-                existing = json.loads(revert_file.read_text())
+                existing = json.loads(revert_file.read_text(encoding="utf-8"))
             existing.append(revert_info)
-            revert_file.write_text(json.dumps(existing, indent=2, default=str))
+            revert_file.write_text(
+                json.dumps(existing, indent=2, default=str),
+                encoding="utf-8",
+            )
             output.files_created.add(str(revert_file))
 
             # Write human-readable revert instruction
             revert_md = self._output_dir / "revert_instructions.md"
-            with open(revert_md, "a") as f:
+            with open(revert_md, "a", encoding="utf-8") as f:
                 f.write(f"## {item.resource_address}\n\n")
                 if ai_root_cause:
                     f.write(f"> 🤖 **AI Root Cause:** {ai_root_cause.narrative}\n\n")
@@ -265,7 +268,7 @@ class RemediationGenerator:
         summary_file = self._output_dir / "REMEDIATION_SUMMARY.md"
         tool_name = self._iac_tool.value.capitalize()
 
-        with open(summary_file, "w") as f:
+        with open(summary_file, "w", encoding="utf-8") as f:
             f.write("# DriftSentry Remediation Plan\n\n")
             f.write(f"**Scan ID:** `{result.scan_id}`\n")
             f.write(f"**Mode:** {self._mode.value}\n")
@@ -352,7 +355,7 @@ class RemediationGenerator:
         if isinstance(value, int | float):
             return str(value)
         if isinstance(value, str):
-            return f'"{value}"'
+            return json.dumps(value)
         if isinstance(value, list):
             if not value:
                 return "[]"
@@ -361,7 +364,7 @@ class RemediationGenerator:
             return "[" + ", ".join(valid) + "]"
         if isinstance(value, dict):
             return None  # Skip nested blocks for now — complex to serialize
-        return f'"{value}"'
+        return json.dumps(str(value))
 
 
 class RemediationOutput:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+import driftsentry.cli.scan as scan_module
 from driftsentry.cli.main import app
 
 runner = CliRunner()
@@ -83,4 +84,28 @@ def test_cli_report_html(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0
     assert html_out.exists()
-    assert "<!DOCTYPE html>" in html_out.read_text()
+    assert "<!DOCTYPE html>" in html_out.read_text(encoding="utf-8")
+
+
+def test_last_scan_result_persists_between_invocations(tmp_path: Path, monkeypatch) -> None:
+    result_data = {
+        "scan_id": "persisted",
+        "iac_tool": "terraform",
+        "provider": "aws",
+        "region": "us-east-1",
+        "state_backend": "local",
+        "state_source": "test.tfstate",
+        "drift_items": [],
+        "duration_seconds": 0.5,
+        "errors": [],
+    }
+    from driftsentry.core.models import DriftResult
+
+    monkeypatch.chdir(tmp_path)
+    scan_module._last_scan_result = None
+    scan_module._save_last_scan_result(DriftResult(**result_data))
+
+    loaded = scan_module.get_last_scan_result()
+
+    assert loaded is not None
+    assert loaded.scan_id == "persisted"

--- a/tests/unit/test_differ.py
+++ b/tests/unit/test_differ.py
@@ -119,3 +119,28 @@ def test_differ_ignores_noise_attributes(
 
     item = differ.diff_resource(mock_ec2_resource, noisy_cloud)
     assert item is None
+
+
+def test_differ_redacts_sensitive_values() -> None:
+    differ = DriftDiffer()
+    state = ResourceState(
+        address="aws_db_instance.prod",
+        resource_type="aws_db_instance",
+        resource_name="prod",
+        provider="aws",
+        resource_id="db-123",
+        attributes={"id": "db-123", "password": "old-secret"},
+        sensitive_attributes=["password"],
+    )
+    cloud = CloudResource(
+        resource_id="db-123",
+        resource_type="aws_db_instance",
+        attributes={"id": "db-123", "password": "new-secret"},
+    )
+
+    item = differ.diff_resource(state, cloud)
+
+    assert item is not None
+    assert item.attribute_diffs[0].is_sensitive
+    assert item.attribute_diffs[0].desired_value == "[REDACTED]"
+    assert item.attribute_diffs[0].actual_value == "[REDACTED]"

--- a/tests/unit/test_remediation.py
+++ b/tests/unit/test_remediation.py
@@ -99,6 +99,12 @@ def test_remediation_opentofu_support(tmp_path: Path) -> None:
     assert output.import_commands[0].startswith("opentofu import")
 
 
+def test_hcl_string_values_are_escaped() -> None:
+    escaped = RemediationGenerator._to_hcl_value('quoted "value"\nnext')
+
+    assert escaped == '"quoted \\"value\\"\\nnext"'
+
+
 def test_remediation_revert_plan(tmp_path: Path) -> None:
     item = DriftItem(
         resource_address="aws_instance.web",
@@ -220,5 +226,5 @@ def test_remediation_with_ai(tmp_path: Path) -> None:
 
     revert_file = tmp_path / "revert_instructions.md"
     assert revert_file.exists()
-    revert_content = revert_file.read_text()
+    revert_content = revert_file.read_text(encoding="utf-8")
     assert "AI Root Cause:" in revert_content

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -132,3 +132,24 @@ def test_scanner_clean_no_drift(
     assert not result.has_drift
     assert result.total_drifted == 0
     assert result.total_resources == 1
+
+
+def test_scanner_does_not_mark_failed_cloud_scan_as_deleted(
+    mock_ec2_resource: ResourceState,
+) -> None:
+    class FailingCloudProvider(MockCloudProvider):
+        def list_resources(self, resource_type: str) -> list[CloudResource]:
+            raise RuntimeError("AWS unavailable")
+
+    config = DriftSentryConfig()
+    config.attribution.enabled = False
+    scanner = DriftScanner(
+        config,
+        MockStateReader([mock_ec2_resource]),
+        FailingCloudProvider({"aws_instance": []}),
+    )
+
+    result = scanner.scan(show_progress=False)
+
+    assert result.deleted_count == 0
+    assert result.errors == ["Error scanning aws_instance: AWS unavailable"]


### PR DESCRIPTION

Persist the latest scan result for separate report and remediate commands.
Prevent failed AWS scans from being reported as deleted resources.
Redact sensitive Terraform attributes from diffs and JSON reports.
Escape generated HCL string values correctly.
Use UTF-8 encoding for generated remediation and report files.
Remove obsolete mypy suppressions.
Add regression tests for all fixes.

**Testing**

48 passed
Ruff checks passed
Mypy checks passed
git diff --check passed