### PR TITLE
chore: add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ import.sh
 driftsentry-pr-*/
 
 # Agent & LLM IDE configs
+CLAUDE.md
 .agents/
 .claude/
 


### PR DESCRIPTION
Add `CLAUDE.md` to the gitignore so AI agent context files stay local-only.