### PR TITLE
feat(history): add SQLite-backed drift history store

### DIFF
--- a/.driftsentry.yaml.example
+++ b/.driftsentry.yaml.example
@@ -60,6 +60,12 @@ remediation:
 #   max_items: 20                 # Max drift items to process with AI
 #   thinking_budget: 5000         # Token budget for LLM extended thinking
 
+# Durable scan history persistence (SQLite-backed)
+history:
+  enabled: true
+  # db_path: "~/.driftsentry/history.db"  # Override default database path
+  retention_days: 90  # Auto-prune scan history older than this many days
+
 # Notification settings
 notifications:
   # slack_webhook_url: "${DRIFTSENTRY_SLACK_WEBHOOK}"

--- a/src/driftsentry/cli/scan.py
+++ b/src/driftsentry/cli/scan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import typer
@@ -11,12 +12,14 @@ from rich.console import Console
 from driftsentry.core.config import load_config
 from driftsentry.core.models import DriftResult, IaCTool, StateBackendType
 from driftsentry.core.scanner import DriftScanner
+from driftsentry.history.store import DriftStore
 from driftsentry.output.json_fmt import JSONFormatter
 from driftsentry.output.table import TableFormatter
 from driftsentry.policy.engine import PolicyEngine
 from driftsentry.providers.aws.provider import AWSProvider
 from driftsentry.state.factory import create_state_reader
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 # ─── Shared state for passing scan results to report/remediate ──
@@ -276,6 +279,18 @@ def scan(
     # Store for report/remediate commands
     _last_scan_result = result
     _save_last_scan_result(result)
+
+    # Persist to durable history store
+    if config.history.enabled:
+        try:
+            history_db_path = Path(config.history.db_path) if config.history.db_path else None
+            history_store = DriftStore(db_path=history_db_path)
+            try:
+                history_store.save(result)
+            finally:
+                history_store.close()
+        except Exception as e:
+            logger.warning(f"Failed to persist scan result to history store: {e}")
 
     # Output
     if output_format == "json":

--- a/src/driftsentry/core/config.py
+++ b/src/driftsentry/core/config.py
@@ -179,6 +179,20 @@ class ScanFilters(BaseModel):
     )
 
 
+class HistoryConfig(BaseModel):
+    """Configuration for durable scan history persistence."""
+
+    enabled: bool = Field(default=True, description="Whether to persist scan results to history")
+    db_path: str | None = Field(
+        default=None,
+        description="Override default history database path (default: ~/.driftsentry/history.db)",
+    )
+    retention_days: int = Field(
+        default=90,
+        description="Auto-prune scan history older than this many days",
+    )
+
+
 class LLMConfig(BaseModel):
     """Configuration for AI-powered smart remediation."""
 
@@ -217,6 +231,7 @@ class DriftSentryConfig(BaseModel):
     notifications: NotificationConfig = Field(default_factory=NotificationConfig)
     filters: ScanFilters = Field(default_factory=ScanFilters)
     llm: LLMConfig = Field(default_factory=LLMConfig)
+    history: HistoryConfig = Field(default_factory=HistoryConfig)
     verbose: bool = Field(default=False, description="Enable verbose output")
 
 

--- a/src/driftsentry/history/__init__.py
+++ b/src/driftsentry/history/__init__.py
@@ -1,0 +1,13 @@
+"""Drift history storage — durable, queryable persistence of scan results."""
+
+from __future__ import annotations
+
+from driftsentry.history.models import DriftItemSnapshot, ScanSnapshot
+from driftsentry.history.store import DriftStore, DriftStoreError
+
+__all__ = [
+    "DriftItemSnapshot",
+    "DriftStore",
+    "DriftStoreError",
+    "ScanSnapshot",
+]

--- a/src/driftsentry/history/models.py
+++ b/src/driftsentry/history/models.py
@@ -1,0 +1,53 @@
+"""Pydantic models for the drift history store.
+
+Defines the normalized, queryable records persisted by `DriftStore`:
+a per-scan summary (`ScanSnapshot`) and per-resource drift records
+(`DriftItemSnapshot`) linked to a scan.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ScanSnapshot(BaseModel):
+    """A lightweight summary of a `DriftResult`, persisted as one history row."""
+
+    scan_id: str = Field(description="Unique identifier for this scan run")
+    timestamp: datetime.datetime = Field(description="When the scan was performed")
+    total_resources: int = Field(default=0, description="Total managed resources in state")
+    total_drifted: int = Field(default=0, description="Total number of drifted resources")
+    changed_count: int = Field(default=0, description="Count of resources with attribute changes")
+    deleted_count: int = Field(default=0, description="Count of resources deleted from the cloud")
+    unmanaged_count: int = Field(default=0, description="Count of unmanaged (shadow IT) resources")
+    critical_count: int = Field(default=0, description="Count of critical-severity drift items")
+    duration_seconds: float = Field(default=0.0, description="Scan duration in seconds")
+    state_source: str = Field(default="", description="State file path or backend location")
+    regions: list[str] = Field(default_factory=list, description="All cloud regions scanned")
+    accounts: list[str] = Field(
+        default_factory=list, description="All cloud account IDs/aliases scanned"
+    )
+    errors_count: int = Field(
+        default=0, description="Number of non-fatal errors encountered during the scan"
+    )
+
+
+class DriftItemSnapshot(BaseModel):
+    """A per-resource drift record linked to a scan."""
+
+    scan_id: str = Field(description="ID of the scan this drift item belongs to")
+    resource_address: str = Field(description="Terraform address, e.g. 'aws_instance.web'")
+    resource_type: str = Field(description="Resource type, e.g. 'aws_instance'")
+    resource_id: str | None = Field(default=None, description="Cloud resource ID")
+    drift_type: str = Field(description="Type of drift detected")
+    severity: str = Field(description="Severity level")
+    account_id: str | None = Field(default=None, description="AWS account ID")
+    region: str | None = Field(default=None, description="Cloud region")
+    attribution_principal: str | None = Field(
+        default=None, description="IAM principal who made the change"
+    )
+    attribution_event_time: datetime.datetime | None = Field(
+        default=None, description="When the change was made"
+    )

--- a/src/driftsentry/history/store.py
+++ b/src/driftsentry/history/store.py
@@ -1,0 +1,296 @@
+"""SQLite-backed durable history store for drift scan results.
+
+`DriftStore` persists every `DriftResult` as a normalized `ScanSnapshot`
+row plus per-resource `DriftItemSnapshot` rows, enabling queries like
+"how many scans over time" or "history of a specific resource" without
+holding the full scan payload in memory or on disk as a JSON blob.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import sqlite3
+from pathlib import Path
+
+from driftsentry.core.models import DriftResult
+from driftsentry.history.models import DriftItemSnapshot, ScanSnapshot
+
+DEFAULT_DB_PATH = Path.home() / ".driftsentry" / "history.db"
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS scan_snapshots (
+    scan_id            TEXT PRIMARY KEY,
+    timestamp          TEXT NOT NULL,
+    total_resources    INTEGER NOT NULL DEFAULT 0,
+    total_drifted      INTEGER NOT NULL DEFAULT 0,
+    changed_count      INTEGER NOT NULL DEFAULT 0,
+    deleted_count      INTEGER NOT NULL DEFAULT 0,
+    unmanaged_count    INTEGER NOT NULL DEFAULT 0,
+    critical_count     INTEGER NOT NULL DEFAULT 0,
+    duration_seconds   REAL NOT NULL DEFAULT 0.0,
+    state_source       TEXT NOT NULL DEFAULT '',
+    regions            TEXT NOT NULL DEFAULT '[]',
+    accounts           TEXT NOT NULL DEFAULT '[]',
+    errors_count       INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS drift_item_snapshots (
+    id                     INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_id                TEXT NOT NULL REFERENCES scan_snapshots(scan_id) ON DELETE CASCADE,
+    resource_address       TEXT NOT NULL,
+    resource_type          TEXT NOT NULL,
+    resource_id            TEXT,
+    drift_type             TEXT NOT NULL,
+    severity               TEXT NOT NULL,
+    account_id             TEXT,
+    region                 TEXT,
+    attribution_principal  TEXT,
+    attribution_event_time TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_drift_items_scan_id ON drift_item_snapshots(scan_id);
+CREATE INDEX IF NOT EXISTS idx_drift_items_resource ON drift_item_snapshots(resource_address);
+"""
+
+_SCHEMA_VERSION = 1
+
+
+class DriftStoreError(Exception):
+    """Raised when the drift history database cannot be opened or initialized."""
+
+
+class DriftStore:
+    """SQLite-backed store for durable drift scan history."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        """Open (and if necessary create) the drift history database.
+
+        Args:
+            db_path: Path to the SQLite database file. Defaults to
+                `~/.driftsentry/history.db`. The parent directory is
+                created automatically if it doesn't exist.
+
+        Raises:
+            DriftStoreError: If the database file exists but is corrupted
+                or otherwise cannot be initialized.
+        """
+        self.db_path = db_path if db_path is not None else DEFAULT_DB_PATH
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        try:
+            self._conn = sqlite3.connect(str(self.db_path))
+            self._conn.execute("PRAGMA foreign_keys = ON")
+            self._conn.row_factory = sqlite3.Row
+            with self._conn:
+                self._conn.executescript(_SCHEMA)
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO schema_version (version) VALUES (?)",
+                    (_SCHEMA_VERSION,),
+                )
+        except sqlite3.DatabaseError as e:
+            raise DriftStoreError(f"Failed to initialize drift history database: {e}") from e
+
+    def save(self, result: DriftResult) -> ScanSnapshot:
+        """Persist a `DriftResult` as a scan snapshot plus its drift items.
+
+        The snapshot row and all drift item rows are written within a
+        single transaction.
+        """
+        snapshot = ScanSnapshot(
+            scan_id=result.scan_id,
+            timestamp=result.timestamp,
+            total_resources=result.total_resources,
+            total_drifted=result.total_drifted,
+            changed_count=result.changed_count,
+            deleted_count=result.deleted_count,
+            unmanaged_count=result.unmanaged_count,
+            critical_count=result.critical_count,
+            duration_seconds=result.duration_seconds,
+            state_source=result.state_source,
+            regions=result.regions,
+            accounts=result.accounts,
+            errors_count=len(result.errors),
+        )
+
+        with self._conn:
+            self._conn.execute(
+                """
+                INSERT OR REPLACE INTO scan_snapshots (
+                    scan_id, timestamp, total_resources, total_drifted,
+                    changed_count, deleted_count, unmanaged_count, critical_count,
+                    duration_seconds, state_source, regions, accounts, errors_count
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    snapshot.scan_id,
+                    snapshot.timestamp.isoformat(),
+                    snapshot.total_resources,
+                    snapshot.total_drifted,
+                    snapshot.changed_count,
+                    snapshot.deleted_count,
+                    snapshot.unmanaged_count,
+                    snapshot.critical_count,
+                    snapshot.duration_seconds,
+                    snapshot.state_source,
+                    json.dumps(snapshot.regions),
+                    json.dumps(snapshot.accounts),
+                    snapshot.errors_count,
+                ),
+            )
+            self._conn.execute(
+                "DELETE FROM drift_item_snapshots WHERE scan_id = ?", (snapshot.scan_id,)
+            )
+            for item in result.drift_items:
+                attribution_principal = item.attribution.principal if item.attribution else None
+                attribution_event_time = (
+                    item.attribution.event_time.isoformat()
+                    if item.attribution and item.attribution.event_time
+                    else None
+                )
+                self._conn.execute(
+                    """
+                    INSERT INTO drift_item_snapshots (
+                        scan_id, resource_address, resource_type, resource_id,
+                        drift_type, severity, account_id, region,
+                        attribution_principal, attribution_event_time
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        snapshot.scan_id,
+                        item.resource_address,
+                        item.resource_type,
+                        item.resource_id,
+                        str(item.drift_type),
+                        str(item.severity),
+                        item.account_id,
+                        item.region,
+                        attribution_principal,
+                        attribution_event_time,
+                    ),
+                )
+
+        return snapshot
+
+    def get_latest(self) -> ScanSnapshot | None:
+        """Return the most recent scan snapshot, or None if history is empty."""
+        row = self._conn.execute(
+            "SELECT * FROM scan_snapshots ORDER BY timestamp DESC LIMIT 1"
+        ).fetchone()
+        return self._row_to_snapshot(row) if row else None
+
+    def get_snapshot(self, scan_id: str) -> ScanSnapshot | None:
+        """Retrieve a specific scan snapshot by ID, or None if not found."""
+        row = self._conn.execute(
+            "SELECT * FROM scan_snapshots WHERE scan_id = ?", (scan_id,)
+        ).fetchone()
+        return self._row_to_snapshot(row) if row else None
+
+    def list_snapshots(
+        self,
+        limit: int = 50,
+        since: datetime.datetime | None = None,
+        before: datetime.datetime | None = None,
+    ) -> list[ScanSnapshot]:
+        """List scan snapshots, most recent first, with optional time-range filtering.
+
+        Args:
+            limit: Maximum number of snapshots to return.
+            since: Only include scans at or after this timestamp.
+            before: Only include scans at or before this timestamp.
+        """
+        query = "SELECT * FROM scan_snapshots WHERE 1=1"
+        params: list[str | int] = []
+        if since is not None:
+            query += " AND timestamp >= ?"
+            params.append(since.isoformat())
+        if before is not None:
+            query += " AND timestamp <= ?"
+            params.append(before.isoformat())
+        query += " ORDER BY timestamp DESC LIMIT ?"
+        params.append(limit)
+
+        rows = self._conn.execute(query, params).fetchall()
+        return [self._row_to_snapshot(row) for row in rows]
+
+    def get_drift_items(self, scan_id: str) -> list[DriftItemSnapshot]:
+        """Retrieve all drift items recorded for a given scan."""
+        rows = self._conn.execute(
+            "SELECT * FROM drift_item_snapshots WHERE scan_id = ? ORDER BY id",
+            (scan_id,),
+        ).fetchall()
+        return [self._row_to_drift_item(row) for row in rows]
+
+    def get_resource_history(
+        self, resource_address: str, limit: int = 20
+    ) -> list[DriftItemSnapshot]:
+        """Get the drift history for a specific resource across scans, most recent first."""
+        rows = self._conn.execute(
+            """
+            SELECT drift_item_snapshots.*
+            FROM drift_item_snapshots
+            JOIN scan_snapshots ON scan_snapshots.scan_id = drift_item_snapshots.scan_id
+            WHERE drift_item_snapshots.resource_address = ?
+            ORDER BY scan_snapshots.timestamp DESC
+            LIMIT ?
+            """,
+            (resource_address, limit),
+        ).fetchall()
+        return [self._row_to_drift_item(row) for row in rows]
+
+    def delete_before(self, before: datetime.datetime) -> int:
+        """Delete scan snapshots (and their drift items) older than `before`.
+
+        Returns:
+            The number of scan snapshots deleted.
+        """
+        with self._conn:
+            cursor = self._conn.execute(
+                "DELETE FROM scan_snapshots WHERE timestamp < ?", (before.isoformat(),)
+            )
+            return cursor.rowcount
+
+    def close(self) -> None:
+        """Close the underlying database connection."""
+        self._conn.close()
+
+    @staticmethod
+    def _row_to_snapshot(row: sqlite3.Row) -> ScanSnapshot:
+        return ScanSnapshot(
+            scan_id=row["scan_id"],
+            timestamp=datetime.datetime.fromisoformat(row["timestamp"]),
+            total_resources=row["total_resources"],
+            total_drifted=row["total_drifted"],
+            changed_count=row["changed_count"],
+            deleted_count=row["deleted_count"],
+            unmanaged_count=row["unmanaged_count"],
+            critical_count=row["critical_count"],
+            duration_seconds=row["duration_seconds"],
+            state_source=row["state_source"],
+            regions=json.loads(row["regions"]),
+            accounts=json.loads(row["accounts"]),
+            errors_count=row["errors_count"],
+        )
+
+    @staticmethod
+    def _row_to_drift_item(row: sqlite3.Row) -> DriftItemSnapshot:
+        return DriftItemSnapshot(
+            scan_id=row["scan_id"],
+            resource_address=row["resource_address"],
+            resource_type=row["resource_type"],
+            resource_id=row["resource_id"],
+            drift_type=row["drift_type"],
+            severity=row["severity"],
+            account_id=row["account_id"],
+            region=row["region"],
+            attribution_principal=row["attribution_principal"],
+            attribution_event_time=(
+                datetime.datetime.fromisoformat(row["attribution_event_time"])
+                if row["attribution_event_time"]
+                else None
+            ),
+        )

--- a/tests/unit/test_history_store.py
+++ b/tests/unit/test_history_store.py
@@ -1,0 +1,308 @@
+"""Unit tests for the SQLite-backed drift history store."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+
+import pytest
+
+from driftsentry.core.models import (
+    AttributeDiff,
+    DriftAttribution,
+    DriftItem,
+    DriftResult,
+    DriftSeverity,
+    DriftType,
+    StateBackendType,
+)
+from driftsentry.history.store import DriftStore, DriftStoreError
+
+
+def _make_result(
+    scan_id: str = "scan-1",
+    timestamp: datetime.datetime | None = None,
+    resource_address: str = "aws_security_group.web",
+) -> DriftResult:
+    item = DriftItem(
+        resource_address=resource_address,
+        resource_type="aws_security_group",
+        resource_id="sg-12345",
+        drift_type=DriftType.CHANGED,
+        severity=DriftSeverity.CRITICAL,
+        attribute_diffs=[
+            AttributeDiff(
+                path="ingress.0.cidr_blocks",
+                desired_value=["10.0.0.0/8"],
+                actual_value=["0.0.0.0/0"],
+            )
+        ],
+        attribution=DriftAttribution(
+            principal="arn:aws:iam::123456789012:user/alice",
+            event_time=datetime.datetime(2026, 1, 1, 12, 0, 0),
+        ),
+        account_id="123456789012",
+        region="us-east-1",
+    )
+    return DriftResult(
+        scan_id=scan_id,
+        timestamp=timestamp or datetime.datetime(2026, 1, 1, 12, 0, 0),
+        provider="aws",
+        regions=["us-east-1"],
+        accounts=["123456789012"],
+        state_backend=StateBackendType.LOCAL,
+        state_source="test.tfstate",
+        total_resources=10,
+        drift_items=[item],
+        duration_seconds=1.5,
+        errors=["a warning"],
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> Path:
+    return tmp_path / "history.db"
+
+
+def test_schema_creation_on_fresh_database(db_path: Path) -> None:
+    assert not db_path.exists()
+    store = DriftStore(db_path=db_path)
+    try:
+        assert db_path.exists()
+        tables = {
+            row[0]
+            for row in store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert {"schema_version", "scan_snapshots", "drift_item_snapshots"} <= tables
+        version_row = store._conn.execute("SELECT version FROM schema_version").fetchone()
+        assert version_row is not None
+    finally:
+        store.close()
+
+
+def test_default_db_path_not_touched_by_temp_store(
+    db_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Sanity check: instantiating with an explicit path has no side effects
+    # on the real filesystem default location.
+    fake_home = db_path.parent / "fake_home"
+    monkeypatch.setattr(
+        "driftsentry.history.store.DEFAULT_DB_PATH", fake_home / ".driftsentry" / "history.db"
+    )
+    store = DriftStore(db_path=db_path)
+    store.close()
+    assert not fake_home.exists()
+
+
+def test_save_and_get_snapshot_round_trip(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        result = _make_result()
+        saved = store.save(result)
+
+        assert saved.scan_id == "scan-1"
+        assert saved.total_resources == 10
+        assert saved.total_drifted == 1
+        assert saved.changed_count == 1
+        assert saved.deleted_count == 0
+        assert saved.unmanaged_count == 0
+        assert saved.critical_count == 1
+        assert saved.duration_seconds == 1.5
+        assert saved.state_source == "test.tfstate"
+        assert saved.regions == ["us-east-1"]
+        assert saved.accounts == ["123456789012"]
+        assert saved.errors_count == 1
+
+        fetched = store.get_snapshot("scan-1")
+        assert fetched is not None
+        assert fetched == saved
+    finally:
+        store.close()
+
+
+def test_get_snapshot_missing_returns_none(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        assert store.get_snapshot("does-not-exist") is None
+    finally:
+        store.close()
+
+
+def test_get_latest_returns_most_recent(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        store.save(_make_result(scan_id="scan-1", timestamp=datetime.datetime(2026, 1, 1)))
+        store.save(_make_result(scan_id="scan-2", timestamp=datetime.datetime(2026, 1, 3)))
+        store.save(_make_result(scan_id="scan-3", timestamp=datetime.datetime(2026, 1, 2)))
+
+        latest = store.get_latest()
+        assert latest is not None
+        assert latest.scan_id == "scan-2"
+    finally:
+        store.close()
+
+
+def test_get_latest_empty_store_returns_none(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        assert store.get_latest() is None
+    finally:
+        store.close()
+
+
+def test_get_drift_items_for_scan(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        result = _make_result()
+        store.save(result)
+
+        items = store.get_drift_items("scan-1")
+        assert len(items) == 1
+        item = items[0]
+        assert item.scan_id == "scan-1"
+        assert item.resource_address == "aws_security_group.web"
+        assert item.resource_type == "aws_security_group"
+        assert item.resource_id == "sg-12345"
+        assert item.drift_type == "changed"
+        assert item.severity == "critical"
+        assert item.account_id == "123456789012"
+        assert item.region == "us-east-1"
+        assert item.attribution_principal == "arn:aws:iam::123456789012:user/alice"
+        assert item.attribution_event_time == datetime.datetime(2026, 1, 1, 12, 0, 0)
+    finally:
+        store.close()
+
+
+def test_list_snapshots_time_range_filtering(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        store.save(_make_result(scan_id="scan-1", timestamp=datetime.datetime(2026, 1, 1)))
+        store.save(_make_result(scan_id="scan-2", timestamp=datetime.datetime(2026, 1, 5)))
+        store.save(_make_result(scan_id="scan-3", timestamp=datetime.datetime(2026, 1, 10)))
+
+        all_snapshots = store.list_snapshots(limit=50)
+        assert [s.scan_id for s in all_snapshots] == ["scan-3", "scan-2", "scan-1"]
+
+        since_filtered = store.list_snapshots(since=datetime.datetime(2026, 1, 4))
+        assert [s.scan_id for s in since_filtered] == ["scan-3", "scan-2"]
+
+        before_filtered = store.list_snapshots(before=datetime.datetime(2026, 1, 6))
+        assert [s.scan_id for s in before_filtered] == ["scan-2", "scan-1"]
+
+        range_filtered = store.list_snapshots(
+            since=datetime.datetime(2026, 1, 2), before=datetime.datetime(2026, 1, 9)
+        )
+        assert [s.scan_id for s in range_filtered] == ["scan-2"]
+
+        limited = store.list_snapshots(limit=1)
+        assert [s.scan_id for s in limited] == ["scan-3"]
+    finally:
+        store.close()
+
+
+def test_get_resource_history_across_scans(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        store.save(
+            _make_result(
+                scan_id="scan-1",
+                timestamp=datetime.datetime(2026, 1, 1),
+                resource_address="aws_security_group.web",
+            )
+        )
+        store.save(
+            _make_result(
+                scan_id="scan-2",
+                timestamp=datetime.datetime(2026, 1, 2),
+                resource_address="aws_instance.other",
+            )
+        )
+        store.save(
+            _make_result(
+                scan_id="scan-3",
+                timestamp=datetime.datetime(2026, 1, 3),
+                resource_address="aws_security_group.web",
+            )
+        )
+
+        history = store.get_resource_history("aws_security_group.web")
+        assert [h.scan_id for h in history] == ["scan-3", "scan-1"]
+
+        limited = store.get_resource_history("aws_security_group.web", limit=1)
+        assert [h.scan_id for h in limited] == ["scan-3"]
+
+        assert store.get_resource_history("does.not.exist") == []
+    finally:
+        store.close()
+
+
+def test_delete_before_prunes_old_records(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        store.save(_make_result(scan_id="scan-1", timestamp=datetime.datetime(2026, 1, 1)))
+        store.save(_make_result(scan_id="scan-2", timestamp=datetime.datetime(2026, 1, 5)))
+        store.save(_make_result(scan_id="scan-3", timestamp=datetime.datetime(2026, 1, 10)))
+
+        deleted = store.delete_before(datetime.datetime(2026, 1, 6))
+        assert deleted == 2
+
+        remaining = store.list_snapshots(limit=50)
+        assert [s.scan_id for s in remaining] == ["scan-3"]
+
+        # Drift items for pruned scans should be cascade-deleted.
+        assert store.get_drift_items("scan-1") == []
+    finally:
+        store.close()
+
+
+def test_concurrent_access_two_store_instances(db_path: Path) -> None:
+    store_a = DriftStore(db_path=db_path)
+    store_b = DriftStore(db_path=db_path)
+    try:
+        store_a.save(_make_result(scan_id="scan-1"))
+        # Second connection to the same underlying database file should see it.
+        fetched = store_b.get_snapshot("scan-1")
+        assert fetched is not None
+        assert fetched.scan_id == "scan-1"
+
+        store_b.save(_make_result(scan_id="scan-2", timestamp=datetime.datetime(2026, 1, 2)))
+        snapshots = store_a.list_snapshots(limit=50)
+        assert {s.scan_id for s in snapshots} == {"scan-1", "scan-2"}
+    finally:
+        store_a.close()
+        store_b.close()
+
+
+def test_corrupted_database_file_raises_clear_error(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    db_path.write_bytes(b"this is not a valid sqlite database file")
+
+    with pytest.raises(DriftStoreError):
+        DriftStore(db_path=db_path)
+
+
+def test_missing_database_file_is_created(tmp_path: Path) -> None:
+    nested_path = tmp_path / "nested" / "dir" / "history.db"
+    assert not nested_path.parent.exists()
+
+    store = DriftStore(db_path=nested_path)
+    try:
+        assert nested_path.exists()
+        assert store.get_latest() is None
+    finally:
+        store.close()
+
+
+def test_save_overwrites_existing_scan_id(db_path: Path) -> None:
+    store = DriftStore(db_path=db_path)
+    try:
+        store.save(_make_result(scan_id="scan-1", resource_address="aws_instance.a"))
+        store.save(_make_result(scan_id="scan-1", resource_address="aws_instance.b"))
+
+        items = store.get_drift_items("scan-1")
+        assert len(items) == 1
+        assert items[0].resource_address == "aws_instance.b"
+    finally:
+        store.close()


### PR DESCRIPTION
## Summary

Adds a durable, queryable SQLite-backed history store for drift scan results (Part 1 of the `continuous-drift-monitoring` feature — Parts 2/3 build on this). Every `driftsentry scan` run now persists a normalized snapshot of its results to `~/.driftsentry/history.db` (configurable), enabling later features like trend reporting and per-resource drift history without holding full scan payloads in memory.

## What's new

- **`src/driftsentry/history/` (new module)**
  - `models.py` — `ScanSnapshot` (per-scan summary: counts by drift type/severity, duration, regions/accounts scanned, error count) and `DriftItemSnapshot` (per-resource drift record: address, type, severity, attribution principal/event time).
  - `store.py` — `DriftStore`, a SQLite-backed store with:
    - `save(result)` — writes one `scan_snapshots` row plus one `drift_item_snapshots` row per drifted resource, in a single transaction; overwrites cleanly on scan-id re-save.
    - `get_latest()`, `get_snapshot(scan_id)` — point lookups.
    - `list_snapshots(limit, since, before)` — time-range filtered history, most recent first.
    - `get_drift_items(scan_id)` / `get_resource_history(resource_address, limit)` — per-scan and per-resource (across scans) drift item queries.
    - `delete_before(timestamp)` — retention pruning; drift items cascade-delete with their parent snapshot.
    - Raises `DriftStoreError` on a corrupted/unreadable database file rather than failing silently.
  - `__init__.py` re-exports `DriftStore`, `DriftStoreError`, `ScanSnapshot`, `DriftItemSnapshot`.

- **`src/driftsentry/core/config.py`** — new `HistoryConfig` (`enabled: bool = True`, `db_path: str | None`, `retention_days: int = 90`), wired into `DriftSentryConfig.history`.

- **`src/driftsentry/cli/scan.py`** — after a scan completes, persists the `DriftResult` via `DriftStore.save()` when `config.history.enabled`; store is always closed in a `finally` block, and a persistence failure is logged as a warning rather than failing the scan.

- **`.driftsentry.yaml.example`** — documents the new `history:` config block.

- **`tests/unit/test_history_store.py`** (308 lines, new) — covers schema creation, save/round-trip, `get_latest`/`get_snapshot`, time-range filtering in `list_snapshots`, per-resource history across scans, retention pruning with cascade delete, two concurrent `DriftStore` instances against the same file, and corrupted/missing database handling.

## Config example

```yaml
history:
  enabled: true
  # db_path: "~/.driftsentry/history.db"
  retention_days: 90
```

## Verification

Judge-verified `PASS` — all 6 P0 and 2 P1 spec requirements confirmed against the code, no guardrail violations, no drift from spec. CI green (lint + tests on 3.11/3.12/3.13).

<details>
<summary>Full verdict JSON</summary>

```json
{
  "p0": [
    {
      "id": "p0-1",
      "pass": true,
      "evidence": "src/driftsentry/history/__init__.py, src/driftsentry/history/models.py, and src/driftsentry/history/store.py were created. __init__.py re-exports DriftStore, ScanSnapshot, DriftItemSnapshot, and DriftStoreError."
    },
    {
      "id": "p0-2",
      "pass": true,
      "evidence": "src/driftsentry/history/models.py defines ScanSnapshot (lines 15-34) and DriftItemSnapshot (lines 37-53) with all required fields, descriptions, and type annotations matching the specification."
    },
    {
      "id": "p0-3",
      "pass": true,
      "evidence": "src/driftsentry/history/store.py implements DriftStore with all specified methods: __init__ (lines 70-96), save (lines 98-177), get_latest (lines 179-184), get_snapshot (lines 186-191), list_snapshots (lines 193-218), get_drift_items (lines 220-226), get_resource_history (lines 228-243), delete_before (lines 245-255), and close (lines 257-259)."
    },
    {
      "id": "p0-4",
      "pass": true,
      "evidence": "src/driftsentry/core/config.py defines HistoryConfig (lines 182-193) with enabled (default True), db_path (default None), and retention_days (default 90), and adds history: HistoryConfig to DriftSentryConfig (line 234)."
    },
    {
      "id": "p0-5",
      "pass": true,
      "evidence": "src/driftsentry/cli/scan.py (lines 283-293) instantiates DriftStore and persists DriftResult via history_store.save(result) when config.history.enabled is True, closing the store in a finally block."
    },
    {
      "id": "p0-6",
      "pass": true,
      "evidence": "tests/unit/test_history_store.py covers schema creation (lines 67-83), save/retrieve round-trip (lines 99-123), list_snapshots time-range filtering (lines 178-202), get_resource_history (lines 205-239), delete_before (lines 241-258), concurrent store access (lines 260-276), and corrupted/missing database handling (lines 278-296)."
    }
  ],
  "p1": [
    {
      "id": "p1-1",
      "pass": true,
      "evidence": ".driftsentry.yaml.example (lines 63-67) adds documented history configuration with enabled, db_path, and retention_days."
    },
    {
      "id": "p1-2",
      "pass": true,
      "evidence": "src/driftsentry/history/store.py (lines 22-24, 91-94) creates and populates the schema_version table with _SCHEMA_VERSION = 1 on initialization."
    }
  ],
  "guardrails_ok": true,
  "drift": [],
  "verdict": "PASS",
  "refactor_instructions": "",
  "parse_error": ""
}
```

</details>
