### PR TITLE
fix(tests): resolve pre-existing mypy errors across the test suite

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,8 @@ def sample_state_file() -> Path:
 @pytest.fixture
 def sample_state_dict(sample_state_file: Path) -> dict[str, Any]:
     """Parsed sample .tfstate dictionary."""
-    return json.loads(sample_state_file.read_text())
+    data: dict[str, Any] = json.loads(sample_state_file.read_text())
+    return data
 
 
 @pytest.fixture

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 import driftsentry.cli.scan as scan_module
@@ -140,23 +141,26 @@ def test_cli_scan_multi_region_and_account_flags(sample_state_file: Path) -> Non
         assert call_kwargs["concurrency"] == 8
 
 
-def test_last_scan_result_persists_between_invocations(tmp_path: Path, monkeypatch) -> None:
-    result_data = {
-        "scan_id": "persisted",
-        "iac_tool": "terraform",
-        "provider": "aws",
-        "region": "us-east-1",
-        "state_backend": "local",
-        "state_source": "test.tfstate",
-        "drift_items": [],
-        "duration_seconds": 0.5,
-        "errors": [],
-    }
-    from driftsentry.core.models import DriftResult
+def test_last_scan_result_persists_between_invocations(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from driftsentry.core.models import DriftResult, IaCTool, StateBackendType
+
+    result = DriftResult(
+        scan_id="persisted",
+        iac_tool=IaCTool.TERRAFORM,
+        provider="aws",
+        region="us-east-1",
+        state_backend=StateBackendType.LOCAL,
+        state_source="test.tfstate",
+        drift_items=[],
+        duration_seconds=0.5,
+        errors=[],
+    )
 
     monkeypatch.chdir(tmp_path)
     scan_module._last_scan_result = None
-    scan_module._save_last_scan_result(DriftResult(**result_data))
+    scan_module._save_last_scan_result(result)
 
     loaded = scan_module.get_last_scan_result()
 

--- a/tests/unit/test_monitor.py
+++ b/tests/unit/test_monitor.py
@@ -68,7 +68,9 @@ def config_path(tmp_path: Path) -> str:
 # ─── --max-scans / --once ────────────────────────────────────────
 
 
-def test_monitor_runs_exactly_max_scans_then_exits(monkeypatch, config_path: str) -> None:
+def test_monitor_runs_exactly_max_scans_then_exits(
+    monkeypatch: pytest.MonkeyPatch, config_path: str
+) -> None:
     result = _make_result(["aws_instance.a"])
     scan_mock = MagicMock(return_value=(result, None))
     monkeypatch.setattr(monitor_module, "run_scan_pipeline", scan_mock)
@@ -85,7 +87,7 @@ def test_monitor_runs_exactly_max_scans_then_exits(monkeypatch, config_path: str
 
 
 def test_monitor_once_flag_runs_single_scan_and_ignores_max_scans(
-    monkeypatch, config_path: str
+    monkeypatch: pytest.MonkeyPatch, config_path: str
 ) -> None:
     result = _make_result(["aws_instance.a"])
     scan_mock = MagicMock(return_value=(result, None))
@@ -112,10 +114,10 @@ def test_monitor_rejects_interval_below_minimum(config_path: str) -> None:
 # ─── graceful shutdown ────────────────────────────────────────────
 
 
-def test_monitor_stops_early_on_sigint(monkeypatch, config_path: str) -> None:
+def test_monitor_stops_early_on_sigint(monkeypatch: pytest.MonkeyPatch, config_path: str) -> None:
     result = _make_result(["aws_instance.a"])
 
-    def _scan_then_interrupt(*args, **kwargs):
+    def _scan_then_interrupt(*args: object, **kwargs: object) -> tuple[DriftResult, None]:
         os.kill(os.getpid(), signal.SIGINT)
         return result, None
 

--- a/tests/unit/test_regression.py
+++ b/tests/unit/test_regression.py
@@ -3,39 +3,51 @@
 from __future__ import annotations
 
 import datetime
+from pathlib import Path
 
 import pytest
 
-from driftsentry.core.models import DriftItem, DriftResult, DriftSeverity, DriftType
+from driftsentry.core.models import (
+    DriftItem,
+    DriftResult,
+    DriftSeverity,
+    DriftType,
+    IaCTool,
+    StateBackendType,
+)
 from driftsentry.history.models import DriftDelta
 from driftsentry.history.regression import RegressionDetector
 from driftsentry.history.store import DriftStore
 
 
 @pytest.fixture
-def store(tmp_path):
+def store(tmp_path: Path) -> DriftStore:
     db_path = tmp_path / "test.db"
     return DriftStore(db_path)
 
 
 @pytest.fixture
-def detector(store):
+def detector(store: DriftStore) -> RegressionDetector:
     return RegressionDetector(store)
 
 
-def create_drift_result(scan_id, items):
+def create_drift_result(scan_id: str, items: list[DriftItem]) -> DriftResult:
     return DriftResult(
         scan_id=scan_id,
         timestamp=datetime.datetime.now(),
-        iac_tool="terraform",
+        iac_tool=IaCTool.TERRAFORM,
         provider="aws",
-        state_backend="local",
+        state_backend=StateBackendType.LOCAL,
         state_source="terraform.tfstate",
         drift_items=items,
     )
 
 
-def create_item(address, severity=DriftSeverity.MEDIUM, drift_type=DriftType.CHANGED):
+def create_item(
+    address: str,
+    severity: DriftSeverity = DriftSeverity.MEDIUM,
+    drift_type: DriftType = DriftType.CHANGED,
+) -> DriftItem:
     return DriftItem(
         resource_address=address,
         resource_type="aws_instance",
@@ -44,7 +56,7 @@ def create_item(address, severity=DriftSeverity.MEDIUM, drift_type=DriftType.CHA
     )
 
 
-def test_first_ever_scan(detector):
+def test_first_ever_scan(detector: RegressionDetector) -> None:
     current = create_drift_result("scan-1", [create_item("aws_instance.web1")])
     report = detector.compare(current)
 
@@ -55,7 +67,7 @@ def test_first_ever_scan(detector):
     assert report.items[0].consecutive_scans == 1
 
 
-def test_new_and_recurring(store, detector):
+def test_new_and_recurring(store: DriftStore, detector: RegressionDetector) -> None:
     scan1 = create_drift_result("scan-1", [create_item("aws_instance.web1")])
     store.save(scan1)
 
@@ -83,7 +95,7 @@ def test_new_and_recurring(store, detector):
     assert web2.consecutive_scans == 1
 
 
-def test_resolved(store, detector):
+def test_resolved(store: DriftStore, detector: RegressionDetector) -> None:
     scan1 = create_drift_result("scan-1", [create_item("aws_instance.web1")])
     store.save(scan1)
 
@@ -97,7 +109,7 @@ def test_resolved(store, detector):
     assert report.items[0].consecutive_scans == 1
 
 
-def test_regression(store, detector):
+def test_regression(store: DriftStore, detector: RegressionDetector) -> None:
     # drifted in scan 1
     scan1 = create_drift_result("scan-1", [create_item("aws_instance.web1")])
     store.save(scan1)
@@ -118,7 +130,7 @@ def test_regression(store, detector):
     assert report.items[0].consecutive_scans == 1
 
 
-def test_worsened(store, detector):
+def test_worsened(store: DriftStore, detector: RegressionDetector) -> None:
     scan1 = create_drift_result(
         "scan-1", [create_item("aws_instance.web1", severity=DriftSeverity.LOW)]
     )
@@ -134,7 +146,7 @@ def test_worsened(store, detector):
     assert report.items[0].previous_severity == DriftSeverity.LOW
 
 
-def test_chronic_offenders(store):
+def test_chronic_offenders(store: DriftStore) -> None:
     store.save(create_drift_result("s1", [create_item("r1"), create_item("r2")]))
     store.save(create_drift_result("s2", [create_item("r1"), create_item("r2")]))
     store.save(create_drift_result("s3", [create_item("r1")]))
@@ -149,13 +161,13 @@ def test_chronic_offenders(store):
     assert offenders[0] == ("r1", 3)
 
 
-def test_edge_case_empty(detector):
+def test_edge_case_empty(detector: RegressionDetector) -> None:
     report = detector.compare(create_drift_result("scan-1", []))
     assert report.is_first_scan
     assert len(report.items) == 0
 
 
-def test_resource_matching_by_address(store, detector):
+def test_resource_matching_by_address(store: DriftStore, detector: RegressionDetector) -> None:
     scan1 = create_drift_result("scan-1", [create_item("addr1"), create_item("addr2")])
     store.save(scan1)
 


### PR DESCRIPTION
## Summary
- `make lint` only ever ran `mypy` against `src/driftsentry/`, so the test suite (mostly `test_regression.py`, added with Part 2) accumulated missing type annotations and str-vs-enum mismatches nothing locally ever caught.
- The orchestrator's Stage 1 verification runs `mypy .` (whole repo) and has been silently blocked by this debt on every feature build since — most recently `configurable-continuous-monitoring`, unrelated to any of these files.
- `mypy .` is now clean (0 errors, was ~59).

## Changes
- `conftest.py`: explicit `dict[str, Any]` annotation instead of an implicit `Any` return from `json.loads()`.
- `test_regression.py`: type-annotated all test functions and the `create_drift_result`/`create_item` helpers; `iac_tool`/`state_backend` now pass real `IaCTool`/`StateBackendType` enum members instead of bare strings.
- `test_monitor.py`: annotated `monkeypatch`/`*args`/`**kwargs` parameters missing type hints.
- `test_cli.py`: annotated `monkeypatch`; replaced `DriftResult(**dict)` (which mypy can't verify against the model's individual field types) with explicit keyword arguments.

No behavior changes — type annotations and equivalent enum values only.

## Test plan
- [x] `mypy .` — clean, 0 errors (was ~59)
- [x] `make lint` — clean
- [x] `make test` — 103 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135bJrsdymxdfodiAkoVQhe