### PR TITLE
feat: add live resource discovery and multi-resource AWS scanners

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,6 +40,12 @@ Verify your installation:
 driftsentry version
 ```
 
+> [!TIP]
+> **Windows Users:** If `driftsentry` is not recognized as a command after installing via `pip`, your Python `Scripts` folder is likely not on your system `PATH`. You can:
+> - Run commands directly via module execution: `python -m driftsentry <command>` (or `py -m driftsentry <command>`).
+> - Or add your Python `Scripts` directory (e.g. `%APPDATA%\Python\Python3xx\Scripts` or `%LOCALAPPDATA%\Programs\Python\Python3xx\Scripts`) to your `PATH` environment variable.
+> - Or install via [pipx](https://pypa.github.io/pipx/) which configures PATH automatically: `pipx install driftsentry`.
+
 ---
 
 ## Running with Docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 ]
 
 [project.scripts]
-driftsentry = "driftsentry.cli.main:app"
+driftsentry = "driftsentry.cli.main:main"
 
 [project.urls]
 Homepage = "https://github.com/hemanthkp98/driftsentry"

--- a/src/driftsentry/__main__.py
+++ b/src/driftsentry/__main__.py
@@ -1,0 +1,20 @@
+"""Executable module entrypoint for DriftSentry.
+
+Enables running DriftSentry directly via:
+    python -m driftsentry [args]
+or
+    py -m driftsentry [args] (on Windows)
+"""
+
+from __future__ import annotations
+
+from driftsentry.cli.main import app
+
+
+def main() -> None:
+    """Execute DriftSentry CLI."""
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/driftsentry/attribution/cloudtrail.py
+++ b/src/driftsentry/attribution/cloudtrail.py
@@ -95,6 +95,32 @@ RESOURCE_EVENT_MAP: dict[str, list[str]] = {
         "UpdateService",
         "DeleteService",
     ],
+    "aws_ebs_volume": [
+        "CreateVolume",
+        "DeleteVolume",
+        "ModifyVolume",
+        "ModifyVolumeAttribute",
+    ],
+    "aws_ebs_snapshot": [
+        "CreateSnapshot",
+        "DeleteSnapshot",
+    ],
+    "aws_ami": [
+        "CreateImage",
+        "RegisterImage",
+        "DeregisterImage",
+    ],
+    "aws_rds_cluster": [
+        "CreateDBCluster",
+        "ModifyDBCluster",
+        "DeleteDBCluster",
+    ],
+    "aws_efs_file_system": [
+        "CreateFileSystem",
+        "DeleteFileSystem",
+        "UpdateFileSystem",
+        "PutLifecycleConfiguration",
+    ],
 }
 
 

--- a/src/driftsentry/attribution/cloudtrail.py
+++ b/src/driftsentry/attribution/cloudtrail.py
@@ -121,6 +121,37 @@ RESOURCE_EVENT_MAP: dict[str, list[str]] = {
         "UpdateFileSystem",
         "PutLifecycleConfiguration",
     ],
+    "aws_eip": [
+        "AllocateAddress",
+        "ReleaseAddress",
+        "AssociateAddress",
+        "DisassociateAddress",
+    ],
+    "aws_key_pair": [
+        "CreateKeyPair",
+        "DeleteKeyPair",
+        "ImportKeyPair",
+    ],
+    "aws_network_interface": [
+        "CreateNetworkInterface",
+        "DeleteNetworkInterface",
+        "ModifyNetworkInterfaceAttribute",
+        "AttachNetworkInterface",
+        "DetachNetworkInterface",
+    ],
+    "aws_lb": [
+        "CreateLoadBalancer",
+        "DeleteLoadBalancer",
+        "ModifyLoadBalancerAttributes",
+        "SetSecurityGroups",
+        "SetSubnets",
+    ],
+    "aws_eks_cluster": [
+        "CreateCluster",
+        "DeleteCluster",
+        "UpdateClusterVersion",
+        "UpdateClusterConfig",
+    ],
 }
 
 

--- a/src/driftsentry/cli/discover.py
+++ b/src/driftsentry/cli/discover.py
@@ -1,0 +1,209 @@
+"""Discover command — scan and list live cloud resources without IaC state."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import typer
+from rich.console import Console
+
+from driftsentry.core.config import AccountConfig, load_config
+from driftsentry.discovery.engine import DiscoveryEngine
+from driftsentry.discovery.table import DiscoveryTableFormatter
+from driftsentry.providers.aws.provider import AWSProvider
+
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+def discover(
+    provider: str = typer.Option(
+        "aws",
+        "--provider",
+        "-p",
+        help="Cloud provider: aws",
+    ),
+    region: str | None = typer.Option(
+        None,
+        "--region",
+        "-r",
+        help="Primary cloud region to scan (e.g. us-east-1)",
+    ),
+    regions: str | None = typer.Option(
+        None,
+        "--regions",
+        "-R",
+        help="Comma-separated AWS regions to scan, or 'all'",
+    ),
+    profile: str | None = typer.Option(
+        None,
+        "--profile",
+        help="AWS profile name",
+    ),
+    role_arn: str | None = typer.Option(
+        None,
+        "--role-arn",
+        help="AWS IAM Role ARN to assume",
+    ),
+    accounts: str | None = typer.Option(
+        None,
+        "--accounts",
+        "-A",
+        help="Comma-separated AWS accounts (IDs, names, or profiles) to scan",
+    ),
+    role_arn_template: str | None = typer.Option(
+        None,
+        "--role-arn-template",
+        help="Template for cross-account role assumption, e.g. 'arn:aws:iam::{account_id}:role/DriftSentryScanRole'",
+    ),
+    concurrency: int = typer.Option(
+        4,
+        "--concurrency",
+        help="Max concurrent worker threads for parallel scanning across targets",
+    ),
+    output_format: str = typer.Option(
+        "table",
+        "--output",
+        "-o",
+        help="Output format: table, json",
+    ),
+    include_types: str | None = typer.Option(
+        None,
+        "--include-types",
+        help="Comma-separated resource types to include",
+    ),
+    exclude_types: str | None = typer.Option(
+        None,
+        "--exclude-types",
+        help="Comma-separated resource types to exclude",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show detailed output including ARNs and resource tags",
+    ),
+    save_result: str | None = typer.Option(
+        None,
+        "--save",
+        help="Save discovery result to JSON file",
+    ),
+    config_file: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to .driftsentry.yaml config file",
+    ),
+) -> None:
+    """Discover and list live cloud resources in an AWS account across regions.
+
+    Runs standalone discovery without requiring any Terraform/OpenTofu state files.
+
+    Examples:
+
+        # Scan a single region
+        driftsentry discover --region us-east-1
+
+        # Scan multiple regions
+        driftsentry discover --regions us-east-1,us-west-2
+
+        # Filter by specific resource types
+        driftsentry discover --region us-east-1 --include-types aws_s3_bucket,aws_instance
+
+        # Cross-account scanning
+        driftsentry discover --accounts 111122223333,444455556666 --role-arn-template "arn:aws:iam::{account_id}:role/DriftSentry"
+
+        # Output machine-readable JSON
+        driftsentry discover --region us-east-1 -o json --save inventory.json
+    """
+    # Load optional config file
+    config = load_config(config_file)
+
+    # CLI overrides
+    if region:
+        config.provider.region = region
+    if regions:
+        config.provider.regions = [r.strip() for r in regions.split(",") if r.strip()]
+    if profile:
+        config.provider.profile = profile
+    if role_arn:
+        config.provider.role_arn = role_arn
+    if role_arn_template:
+        config.role_arn_template = role_arn_template
+    if concurrency:
+        config.concurrency = concurrency
+    if accounts:
+        acc_list: list[AccountConfig] = []
+        for a in accounts.split(","):
+            a_clean = a.strip()
+            if not a_clean:
+                continue
+            if a_clean.isdigit() and len(a_clean) == 12:
+                acc_list.append(AccountConfig(id=a_clean))
+            else:
+                acc_list.append(AccountConfig(name=a_clean))
+        config.accounts = acc_list
+
+    resolved_include_types: list[str] | None = None
+    if include_types:
+        resolved_include_types = [t.strip() for t in include_types.split(",") if t.strip()]
+    elif config.filters.include_types:
+        resolved_include_types = list(config.filters.include_types)
+
+    resolved_exclude_types: list[str] | None = None
+    if exclude_types:
+        resolved_exclude_types = [t.strip() for t in exclude_types.split(",") if t.strip()]
+    elif config.filters.exclude_types:
+        resolved_exclude_types = list(config.filters.exclude_types)
+
+    # Initialize cloud provider
+    if provider == "aws":
+        cloud_provider = AWSProvider(
+            region=config.provider.region,
+            regions=config.provider.regions,
+            profile=config.provider.profile,
+            role_arn=config.provider.role_arn,
+            accounts=config.accounts,
+            role_arn_template=config.role_arn_template,
+            custom_resources=config.provider.custom_resources,
+            resource_definitions_dirs=config.provider.resource_definitions_dirs,
+            plugins=config.provider.plugins,
+            concurrency=config.concurrency,
+        )
+    else:
+        console.print(f"[bold red]Error:[/] Unsupported provider: {provider}")
+        raise typer.Exit(code=1)
+
+    # Execute discovery
+    engine = DiscoveryEngine(
+        provider=cloud_provider,
+        include_types=resolved_include_types,
+        exclude_types=resolved_exclude_types,
+    )
+
+    try:
+        result = engine.discover(show_progress=output_format == "table")
+    except Exception as e:
+        console.print(f"[bold red]Error during discovery:[/] {e}")
+        raise typer.Exit(code=1) from None
+
+    # Render output
+    if output_format == "json":
+        json_output = json.dumps(result.model_dump(mode="json"), indent=2, default=str)
+        console.print(json_output)
+    else:
+        formatter = DiscoveryTableFormatter(console=console, verbose=verbose)
+        formatter.render(result)
+
+    # Save to file if requested
+    if save_result:
+        save_path = Path(save_result)
+        save_path.parent.mkdir(parents=True, exist_ok=True)
+        save_path.write_text(
+            json.dumps(result.model_dump(mode="json"), indent=2, default=str),
+            encoding="utf-8",
+        )
+        if output_format != "json":
+            console.print(f"[dim]Discovery result saved to {save_result}[/]")

--- a/src/driftsentry/cli/main.py
+++ b/src/driftsentry/cli/main.py
@@ -61,4 +61,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/src/driftsentry/cli/main.py
+++ b/src/driftsentry/cli/main.py
@@ -54,5 +54,11 @@ def main_callback() -> None:
     pass
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """CLI entry point for DriftSentry."""
     app()
+
+
+if __name__ == "__main__":
+    main()
+

--- a/src/driftsentry/cli/main.py
+++ b/src/driftsentry/cli/main.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 
 from driftsentry import __version__
+from driftsentry.cli.discover import discover
 from driftsentry.cli.history import history_app
 from driftsentry.cli.monitor import monitor
 from driftsentry.cli.remediate import remediate
@@ -34,6 +35,9 @@ app = typer.Typer(
 
 # Register sub-commands
 app.command(name="scan", help="Scan for infrastructure drift")(scan)
+app.command(name="discover", help="Discover and list live cloud resources without IaC state")(
+    discover
+)
 app.command(name="report", help="Generate a drift report from the last scan")(report)
 app.command(name="remediate", help="Generate remediation artifacts and optionally create a PR")(
     remediate

--- a/src/driftsentry/discovery/__init__.py
+++ b/src/driftsentry/discovery/__init__.py
@@ -1,0 +1,13 @@
+"""Discovery package — cloud resource inventory without IaC state."""
+
+from __future__ import annotations
+
+from driftsentry.discovery.engine import DiscoveryEngine
+from driftsentry.discovery.models import DiscoveryResult
+from driftsentry.discovery.table import DiscoveryTableFormatter
+
+__all__ = [
+    "DiscoveryEngine",
+    "DiscoveryResult",
+    "DiscoveryTableFormatter",
+]

--- a/src/driftsentry/discovery/engine.py
+++ b/src/driftsentry/discovery/engine.py
@@ -1,0 +1,113 @@
+"""Discovery engine — orchestrates cloud resource discovery without IaC state."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from driftsentry.core.models import CloudResource
+from driftsentry.discovery.models import DiscoveryResult
+from driftsentry.providers.base import CloudProvider
+
+logger = logging.getLogger(__name__)
+
+
+class DiscoveryEngine:
+    """Discovers and catalogs active cloud resources using a CloudProvider."""
+
+    def __init__(
+        self,
+        provider: CloudProvider,
+        include_types: list[str] | None = None,
+        exclude_types: list[str] | None = None,
+    ) -> None:
+        self._provider = provider
+        self._include_types = set(include_types) if include_types else None
+        self._exclude_types = set(exclude_types) if exclude_types else set()
+
+    def get_scan_types(self) -> list[str]:
+        """Determine the set of resource types to scan based on filters."""
+        supported = set(self._provider.supported_resource_types())
+        types = supported
+
+        if self._include_types:
+            types = types & self._include_types
+
+        types = types - self._exclude_types
+        return sorted(types)
+
+    def discover(self, show_progress: bool = True) -> DiscoveryResult:
+        """Execute discovery across all targeted regions/accounts for all selected types.
+
+        Args:
+            show_progress: Whether to display a terminal spinner/progress bar.
+
+        Returns:
+            DiscoveryResult containing all discovered resources and metadata.
+        """
+        scan_id = str(uuid.uuid4())[:8]
+        start_time = time.time()
+        errors: list[str] = []
+        resources_by_type: dict[str, list[CloudResource]] = {}
+        target_types = self.get_scan_types()
+
+        if show_progress:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                transient=True,
+            ) as progress:
+                task = progress.add_task(
+                    f"🔍 Discovering resources across {len(target_types)} types...",
+                    total=None,
+                )
+                for rtype in target_types:
+                    progress.update(
+                        task,
+                        description=f"🔍 Scanning {rtype}...",
+                    )
+                    try:
+                        found = self._provider.list_resources(rtype)
+                        if found:
+                            resources_by_type[rtype] = found
+                    except Exception as e:
+                        err_msg = f"Failed to list {rtype}: {e}"
+                        errors.append(err_msg)
+                        logger.error(err_msg)
+
+                total_count = sum(len(r) for r in resources_by_type.values())
+                progress.update(
+                    task,
+                    description=f"✅ Discovery complete: found {total_count} resources",
+                )
+        else:
+            for rtype in target_types:
+                try:
+                    found = self._provider.list_resources(rtype)
+                    if found:
+                        resources_by_type[rtype] = found
+                except Exception as e:
+                    err_msg = f"Failed to list {rtype}: {e}"
+                    errors.append(err_msg)
+                    logger.error(err_msg)
+
+        duration = round(time.time() - start_time, 2)
+        total_found = sum(len(r) for r in resources_by_type.values())
+
+        # Extract scanned regions and accounts from provider if available
+        regions = getattr(self._provider, "scanned_regions", [])
+        accounts = getattr(self._provider, "scanned_accounts", [])
+
+        return DiscoveryResult(
+            scan_id=scan_id,
+            provider=self._provider.provider_name,
+            regions=regions,
+            accounts=accounts,
+            total_resources=total_found,
+            resources_by_type=resources_by_type,
+            duration_seconds=duration,
+            errors=errors,
+        )

--- a/src/driftsentry/discovery/models.py
+++ b/src/driftsentry/discovery/models.py
@@ -1,0 +1,35 @@
+"""Data models for cloud resource discovery in DriftSentry."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from driftsentry.core.models import CloudResource
+
+
+class DiscoveryResult(BaseModel):
+    """Result of scanning live cloud infrastructure without IaC state."""
+
+    scan_id: str = Field(description="Unique identifier for this discovery run")
+    provider: str = Field(default="aws", description="Cloud provider name")
+    regions: list[str] = Field(default_factory=list, description="Cloud regions scanned")
+    accounts: list[str] = Field(default_factory=list, description="Account IDs or aliases scanned")
+    total_resources: int = Field(default=0, description="Total count of discovered cloud resources")
+    resources_by_type: dict[str, list[CloudResource]] = Field(
+        default_factory=dict,
+        description="Map of Terraform resource type to list of discovered resources",
+    )
+    duration_seconds: float = Field(
+        default=0.0, description="Total time taken for discovery in seconds"
+    )
+    errors: list[str] = Field(
+        default_factory=list, description="Any errors encountered during scanning"
+    )
+
+    @property
+    def all_resources(self) -> list[CloudResource]:
+        """Flatten all resources into a single list."""
+        flattened: list[CloudResource] = []
+        for resources in self.resources_by_type.values():
+            flattened.extend(resources)
+        return flattened

--- a/src/driftsentry/discovery/table.py
+++ b/src/driftsentry/discovery/table.py
@@ -1,0 +1,133 @@
+"""Rich table formatter for cloud resource discovery output."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+from driftsentry.discovery.models import DiscoveryResult
+
+
+class DiscoveryTableFormatter:
+    """Renders discovery results as beautiful Rich tables in the terminal."""
+
+    def __init__(self, console: Console | None = None, verbose: bool = False) -> None:
+        self.console = console or Console()
+        self.verbose = verbose
+
+    def render(self, result: DiscoveryResult) -> None:
+        """Render the complete discovery report."""
+        self._render_summary_panel(result)
+
+        if result.total_resources > 0:
+            self.console.print()
+            self._render_resources_table(result)
+        else:
+            self.console.print()
+            self.console.print(
+                "  [dim]No active cloud resources found matching the specified criteria.[/]"
+            )
+
+        if result.errors:
+            self.console.print()
+            self._render_errors(result)
+
+        self.console.print()
+
+    def _render_summary_panel(self, result: DiscoveryResult) -> None:
+        """Render the discovery summary panel."""
+        parts = [
+            f"🔍 Discovered: [bold green]{result.total_resources}[/] resources",
+            f"📦 Types: [bold]{len(result.resources_by_type)}[/]",
+            f"⏱  Duration: [bold]{result.duration_seconds}s[/]",
+        ]
+
+        if result.regions:
+            regions_str = ", ".join(result.regions[:5])
+            if len(result.regions) > 5:
+                regions_str += f" (+{len(result.regions) - 5} more)"
+            parts.append(f"🌐 Regions: [bold]{regions_str}[/]")
+
+        if result.accounts:
+            acc_str = ", ".join(result.accounts[:3])
+            if len(result.accounts) > 3:
+                acc_str += f" (+{len(result.accounts) - 3} more)"
+            parts.append(f"🏢 Accounts: [bold]{acc_str}[/]")
+
+        if result.errors:
+            parts.append(f"[bold red]⚠️  Errors: {len(result.errors)}[/]")
+
+        content = "  •  ".join(parts)
+        panel = Panel(
+            content,
+            title="[bold cyan]🛡️  DriftSentry Cloud Discovery[/]",
+            border_style="cyan",
+            padding=(0, 1),
+        )
+        self.console.print(panel)
+
+    def _render_resources_table(self, result: DiscoveryResult) -> None:
+        """Render the tabular breakdown of discovered resources."""
+        table = Table(
+            show_header=True,
+            header_style="bold cyan",
+            border_style="dim",
+            row_styles=["", "dim"],
+            expand=True,
+        )
+
+        table.add_column("Resource Type", style="bold blue", ratio=3)
+        table.add_column("Resource ID", style="green", ratio=3)
+        table.add_column("Name", ratio=3)
+        table.add_column("Region", style="dim", ratio=2)
+        if len(result.accounts) > 1:
+            table.add_column("Account", style="dim", ratio=2)
+        if self.verbose:
+            table.add_column("ARN / Tags", style="dim", ratio=4)
+
+        for rtype in sorted(result.resources_by_type.keys()):
+            for res in result.resources_by_type[rtype]:
+                name = (
+                    res.tags.get("Name")
+                    or res.attributes.get("name")
+                    or res.attributes.get("id")
+                    or "—"
+                )
+                region = res.region or "—"
+                row = [
+                    rtype,
+                    res.resource_id,
+                    name,
+                    region,
+                ]
+                if len(result.accounts) > 1:
+                    account_val = res.account_name or res.account_id or "—"
+                    row.append(account_val)
+                if self.verbose:
+                    detail_parts = []
+                    if res.arn:
+                        detail_parts.append(res.arn)
+                    if res.tags:
+                        tag_str = ", ".join(f"{k}={v}" for k, v in list(res.tags.items())[:3])
+                        detail_parts.append(f"Tags: [{tag_str}]")
+                    row.append(" | ".join(detail_parts) if detail_parts else "—")
+
+                table.add_row(*row)
+
+        self.console.print(table)
+
+    def _render_errors(self, result: DiscoveryResult) -> None:
+        """Render any scan errors encountered."""
+        error_text = Text()
+        for err in result.errors:
+            error_text.append(f"  ⚠️  {err}\n", style="yellow")
+
+        panel = Panel(
+            error_text,
+            title="[bold yellow]Scan Warnings / Errors[/]",
+            border_style="yellow",
+            padding=(0, 1),
+        )
+        self.console.print(panel)

--- a/src/driftsentry/providers/aws/declarative.py
+++ b/src/driftsentry/providers/aws/declarative.py
@@ -210,6 +210,14 @@ class GenericAWSDeclarativeScanner(ResourceScanner):
     def _extract_tags(raw: dict[str, Any]) -> dict[str, str]:
         """Extract resource tags from standard AWS formats."""
         tags_raw = raw.get("Tags") or raw.get("tags") or raw.get("TagList") or []
+        if not tags_raw:
+            # Check if tags are in a nested wrapper dict (e.g. {"cluster": {"tags": ...}})
+            for v in raw.values():
+                if isinstance(v, dict):
+                    tags_raw = v.get("Tags") or v.get("tags") or v.get("TagList") or []
+                    if tags_raw:
+                        break
+
         if isinstance(tags_raw, dict):
             return {str(k): str(v) for k, v in tags_raw.items()}
         if isinstance(tags_raw, list):

--- a/src/driftsentry/providers/aws/provider.py
+++ b/src/driftsentry/providers/aws/provider.py
@@ -75,7 +75,11 @@ class AWSProvider(CloudProvider):
         self._targets: list[ScanTarget] = resolver.resolve_targets()
 
         # Primary region for single-target backwards compatibility
-        self._region = region or (self._targets[0].region if self._targets else "us-east-1")
+        self._region = (
+            region
+            if (region and region.strip().lower() not in ("all", "all-regions"))
+            else (self._targets[0].region if self._targets else "us-east-1")
+        )
 
         # Map target_id -> { resource_type -> ResourceScanner }
         self._target_scanners: dict[str, dict[str, ResourceScanner]] = {}

--- a/src/driftsentry/providers/aws/resources/__init__.py
+++ b/src/driftsentry/providers/aws/resources/__init__.py
@@ -1,5 +1,6 @@
 """AWS resource scanners package."""
 
+from driftsentry.providers.aws.resources.ebs import EBSScanner
 from driftsentry.providers.aws.resources.ec2 import EC2Scanner
 from driftsentry.providers.aws.resources.ecs import ECSScanner
 from driftsentry.providers.aws.resources.iam import IAMScanner
@@ -8,6 +9,7 @@ from driftsentry.providers.aws.resources.rds import RDSScanner
 from driftsentry.providers.aws.resources.s3 import S3Scanner
 
 __all__ = [
+    "EBSScanner",
     "EC2Scanner",
     "ECSScanner",
     "IAMScanner",

--- a/src/driftsentry/providers/aws/resources/ebs.py
+++ b/src/driftsentry/providers/aws/resources/ebs.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import boto3
@@ -80,7 +81,7 @@ class EBSScanner(ResourceScanner):
             pass
         return None
 
-    def _volume_to_cloud_resource(self, vol: dict[str, Any]) -> CloudResource:
+    def _volume_to_cloud_resource(self, vol: Mapping[str, Any]) -> CloudResource:
         vol_id = vol["VolumeId"]
         tags = self._extract_tags(vol.get("Tags", []))
         attrs: dict[str, Any] = {
@@ -129,7 +130,7 @@ class EBSScanner(ResourceScanner):
             pass
         return None
 
-    def _snapshot_to_cloud_resource(self, snap: dict[str, Any]) -> CloudResource:
+    def _snapshot_to_cloud_resource(self, snap: Mapping[str, Any]) -> CloudResource:
         snap_id = snap["SnapshotId"]
         tags = self._extract_tags(snap.get("Tags", []))
         attrs: dict[str, Any] = {
@@ -174,7 +175,7 @@ class EBSScanner(ResourceScanner):
             pass
         return None
 
-    def _image_to_cloud_resource(self, img: dict[str, Any]) -> CloudResource:
+    def _image_to_cloud_resource(self, img: Mapping[str, Any]) -> CloudResource:
         img_id = img["ImageId"]
         tags = self._extract_tags(img.get("Tags", []))
         attrs: dict[str, Any] = {
@@ -201,13 +202,15 @@ class EBSScanner(ResourceScanner):
     # ─── Helpers ────────────────────────────────────────────────────────
 
     @staticmethod
-    def _extract_tags(tags_list: list[dict[str, Any]]) -> dict[str, str]:
+    def _extract_tags(tags_list: Sequence[Mapping[str, Any]] | None) -> dict[str, str]:
         tags: dict[str, str] = {}
+        if not tags_list:
+            return tags
         for tag in tags_list:
             key = tag.get("Key")
             value = tag.get("Value")
             if key and value is not None:
-                tags[key] = str(value)
+                tags[str(key)] = str(value)
         return tags
 
     @staticmethod

--- a/src/driftsentry/providers/aws/resources/ebs.py
+++ b/src/driftsentry/providers/aws/resources/ebs.py
@@ -1,0 +1,216 @@
+"""EBS and AMI resource scanner — volumes, snapshots, and images."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import boto3
+from botocore.exceptions import ClientError
+
+from driftsentry.core.models import CloudResource
+from driftsentry.providers.base import ResourceScanner, register_scanner
+
+logger = logging.getLogger(__name__)
+
+
+@register_scanner("aws")
+class EBSScanner(ResourceScanner):
+    """Scans EBS volumes, EBS snapshots, and custom AMIs."""
+
+    def __init__(self, session: boto3.Session, region: str) -> None:
+        self._ec2 = session.client("ec2", region_name=region)
+        self._region = region
+
+    @property
+    def resource_types(self) -> list[str]:
+        return ["aws_ebs_volume", "aws_ebs_snapshot", "aws_ami"]
+
+    def list_all(self) -> list[CloudResource]:
+        """List all resources across supported EBS and AMI types."""
+        resources: list[CloudResource] = []
+        resources.extend(self._list_volumes())
+        resources.extend(self._list_snapshots())
+        resources.extend(self._list_images())
+        return resources
+
+    def get_by_id(self, resource_id: str) -> CloudResource | None:
+        """Get an EBS/AMI resource by its ID (auto-detects type from ID prefix)."""
+        try:
+            if resource_id.startswith("vol-"):
+                return self._get_volume(resource_id)
+            elif resource_id.startswith("snap-"):
+                return self._get_snapshot(resource_id)
+            elif resource_id.startswith("ami-"):
+                return self._get_image(resource_id)
+        except Exception as e:
+            logger.error(f"Error getting EBS/AMI resource {resource_id}: {e}")
+        return None
+
+    def normalize(self, raw: dict[str, Any]) -> dict[str, Any]:
+        """Normalize EC2 API attributes to match Terraform attribute names."""
+        normalized: dict[str, Any] = {}
+        for key, value in raw.items():
+            tf_key = self._to_snake_case(key)
+            normalized[tf_key] = value
+        return normalized
+
+    # ─── Volumes ────────────────────────────────────────────────────────
+
+    def _list_volumes(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            paginator = self._ec2.get_paginator("describe_volumes")
+            for page in paginator.paginate():
+                for vol in page.get("Volumes", []):
+                    resources.append(self._volume_to_cloud_resource(vol))
+        except Exception as e:
+            logger.error(f"Error listing EBS volumes: {e}")
+            raise
+        return resources
+
+    def _get_volume(self, volume_id: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_volumes(VolumeIds=[volume_id])
+            vols = resp.get("Volumes", [])
+            if vols:
+                return self._volume_to_cloud_resource(vols[0])
+        except ClientError:
+            pass
+        return None
+
+    def _volume_to_cloud_resource(self, vol: dict[str, Any]) -> CloudResource:
+        vol_id = vol["VolumeId"]
+        tags = self._extract_tags(vol.get("Tags", []))
+        attrs: dict[str, Any] = {
+            "id": vol_id,
+            "availability_zone": vol.get("AvailabilityZone"),
+            "size": vol.get("Size"),
+            "volume_type": vol.get("VolumeType"),
+            "iops": vol.get("Iops"),
+            "throughput": vol.get("Throughput"),
+            "encrypted": vol.get("Encrypted", False),
+            "kms_key_id": vol.get("KmsKeyId"),
+            "snapshot_id": vol.get("SnapshotId"),
+            "multi_attach_enabled": vol.get("MultiAttachEnabled", False),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=vol_id,
+            resource_type="aws_ebs_volume",
+            arn=f"arn:aws:ec2:{self._region}::volume/{vol_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
+
+    # ─── Snapshots ──────────────────────────────────────────────────────
+
+    def _list_snapshots(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            paginator = self._ec2.get_paginator("describe_snapshots")
+            for page in paginator.paginate(OwnerIds=["self"]):
+                for snap in page.get("Snapshots", []):
+                    resources.append(self._snapshot_to_cloud_resource(snap))
+        except Exception as e:
+            logger.error(f"Error listing EBS snapshots: {e}")
+            raise
+        return resources
+
+    def _get_snapshot(self, snapshot_id: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_snapshots(SnapshotIds=[snapshot_id])
+            snaps = resp.get("Snapshots", [])
+            if snaps:
+                return self._snapshot_to_cloud_resource(snaps[0])
+        except ClientError:
+            pass
+        return None
+
+    def _snapshot_to_cloud_resource(self, snap: dict[str, Any]) -> CloudResource:
+        snap_id = snap["SnapshotId"]
+        tags = self._extract_tags(snap.get("Tags", []))
+        attrs: dict[str, Any] = {
+            "id": snap_id,
+            "volume_id": snap.get("VolumeId"),
+            "volume_size": snap.get("VolumeSize"),
+            "description": snap.get("Description"),
+            "encrypted": snap.get("Encrypted", False),
+            "kms_key_id": snap.get("KmsKeyId"),
+            "owner_id": snap.get("OwnerId"),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=snap_id,
+            resource_type="aws_ebs_snapshot",
+            arn=f"arn:aws:ec2:{self._region}::snapshot/{snap_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
+
+    # ─── AMIs (Images) ──────────────────────────────────────────────────
+
+    def _list_images(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            resp = self._ec2.describe_images(Owners=["self"])
+            for img in resp.get("Images", []):
+                resources.append(self._image_to_cloud_resource(img))
+        except Exception as e:
+            logger.error(f"Error listing AMIs: {e}")
+            raise
+        return resources
+
+    def _get_image(self, image_id: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_images(ImageIds=[image_id])
+            imgs = resp.get("Images", [])
+            if imgs:
+                return self._image_to_cloud_resource(imgs[0])
+        except ClientError:
+            pass
+        return None
+
+    def _image_to_cloud_resource(self, img: dict[str, Any]) -> CloudResource:
+        img_id = img["ImageId"]
+        tags = self._extract_tags(img.get("Tags", []))
+        attrs: dict[str, Any] = {
+            "id": img_id,
+            "name": img.get("Name"),
+            "description": img.get("Description"),
+            "architecture": img.get("Architecture"),
+            "image_type": img.get("ImageType"),
+            "root_device_name": img.get("RootDeviceName"),
+            "virtualization_type": img.get("VirtualizationType"),
+            "hypervisor": img.get("Hypervisor"),
+            "public": img.get("Public", False),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=img_id,
+            resource_type="aws_ami",
+            arn=f"arn:aws:ec2:{self._region}::image/{img_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
+
+    # ─── Helpers ────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _extract_tags(tags_list: list[dict[str, Any]]) -> dict[str, str]:
+        tags: dict[str, str] = {}
+        for tag in tags_list:
+            key = tag.get("Key")
+            value = tag.get("Value")
+            if key and value is not None:
+                tags[key] = str(value)
+        return tags
+
+    @staticmethod
+    def _to_snake_case(s: str) -> str:
+        s = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", s)
+        return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s).lower()

--- a/src/driftsentry/providers/aws/resources/ec2.py
+++ b/src/driftsentry/providers/aws/resources/ec2.py
@@ -24,7 +24,15 @@ class EC2Scanner(ResourceScanner):
 
     @property
     def resource_types(self) -> list[str]:
-        return ["aws_instance", "aws_security_group", "aws_vpc", "aws_subnet"]
+        return [
+            "aws_instance",
+            "aws_security_group",
+            "aws_vpc",
+            "aws_subnet",
+            "aws_eip",
+            "aws_key_pair",
+            "aws_network_interface",
+        ]
 
     def list_all(self) -> list[CloudResource]:
         """List all EC2 resources across supported types."""
@@ -33,6 +41,9 @@ class EC2Scanner(ResourceScanner):
         resources.extend(self._list_security_groups())
         resources.extend(self._list_vpcs())
         resources.extend(self._list_subnets())
+        resources.extend(self._list_eips())
+        resources.extend(self._list_key_pairs())
+        resources.extend(self._list_network_interfaces())
         return resources
 
     def get_by_id(self, resource_id: str) -> CloudResource | None:
@@ -46,6 +57,21 @@ class EC2Scanner(ResourceScanner):
                 return self._get_vpc(resource_id)
             elif resource_id.startswith("subnet-"):
                 return self._get_subnet(resource_id)
+            elif resource_id.startswith("eipalloc-"):
+                return self._get_eip(resource_id)
+            elif resource_id.startswith("eni-"):
+                return self._get_network_interface(resource_id)
+            elif resource_id.startswith("key-"):
+                return self._get_key_pair(resource_id)
+            else:
+                # Key pairs may be referenced by key name
+                kp = self._get_key_pair(resource_id)
+                if kp is not None:
+                    return kp
+                # EIP may be referenced by public IP
+                eip = self._get_eip_by_ip(resource_id)
+                if eip is not None:
+                    return eip
         except Exception as e:
             logger.error(f"Error getting EC2 resource {resource_id}: {e}")
         return None
@@ -280,6 +306,157 @@ class EC2Scanner(ResourceScanner):
                 tags=self._extract_tags(subnet),
             )
         return None
+
+    # ─── Elastic IPs ─────────────────────────────────────────
+
+    def _list_eips(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            resp = self._ec2.describe_addresses()
+            for addr in resp.get("Addresses", []):
+                resources.append(self._address_to_cloud_resource(addr))
+        except Exception as e:
+            logger.error(f"Error listing Elastic IPs: {e}")
+            raise
+        return resources
+
+    def _get_eip(self, allocation_id: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_addresses(AllocationIds=[allocation_id])
+            addrs = resp.get("Addresses", [])
+            if addrs:
+                return self._address_to_cloud_resource(addrs[0])
+        except Exception:
+            pass
+        return None
+
+    def _get_eip_by_ip(self, public_ip: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_addresses(PublicIps=[public_ip])
+            addrs = resp.get("Addresses", [])
+            if addrs:
+                return self._address_to_cloud_resource(addrs[0])
+        except Exception:
+            pass
+        return None
+
+    def _address_to_cloud_resource(self, addr: Mapping[str, Any]) -> CloudResource:
+        alloc_id = addr.get("AllocationId") or addr.get("PublicIp", "unknown")
+        tags = self._extract_tags(addr)
+        attrs: dict[str, Any] = {
+            "id": alloc_id,
+            "allocation_id": addr.get("AllocationId"),
+            "public_ip": addr.get("PublicIp"),
+            "private_ip_address": addr.get("PrivateIpAddress"),
+            "domain": addr.get("Domain"),
+            "instance": addr.get("InstanceId"),
+            "instance_id": addr.get("InstanceId"),
+            "network_interface_id": addr.get("NetworkInterfaceId"),
+            "network_interface_owner_id": addr.get("NetworkInterfaceOwnerId"),
+            "association_id": addr.get("AssociationId"),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=alloc_id,
+            resource_type="aws_eip",
+            arn=f"arn:aws:ec2:{self._region}::elastic-ip/{alloc_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
+
+    # ─── Key Pairs ───────────────────────────────────────────
+
+    def _list_key_pairs(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            resp = self._ec2.describe_key_pairs()
+            for kp in resp.get("KeyPairs", []):
+                resources.append(self._key_pair_to_cloud_resource(kp))
+        except Exception as e:
+            logger.error(f"Error listing key pairs: {e}")
+            raise
+        return resources
+
+    def _get_key_pair(self, key_id_or_name: str) -> CloudResource | None:
+        try:
+            if key_id_or_name.startswith("key-"):
+                resp = self._ec2.describe_key_pairs(KeyPairIds=[key_id_or_name])
+            else:
+                resp = self._ec2.describe_key_pairs(KeyNames=[key_id_or_name])
+            kps = resp.get("KeyPairs", [])
+            if kps:
+                return self._key_pair_to_cloud_resource(kps[0])
+        except Exception:
+            pass
+        return None
+
+    def _key_pair_to_cloud_resource(self, kp: Mapping[str, Any]) -> CloudResource:
+        key_id = kp.get("KeyPairId") or kp.get("KeyName", "unknown")
+        tags = self._extract_tags(kp)
+        attrs: dict[str, Any] = {
+            "id": kp.get("KeyName") or key_id,
+            "key_name": kp.get("KeyName"),
+            "key_pair_id": kp.get("KeyPairId"),
+            "key_type": kp.get("KeyType"),
+            "fingerprint": kp.get("KeyFingerprint"),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=kp.get("KeyName") or key_id,
+            resource_type="aws_key_pair",
+            arn=f"arn:aws:ec2:{self._region}::key-pair/{key_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
+
+    # ─── Network Interfaces (ENIs) ───────────────────────────
+
+    def _list_network_interfaces(self) -> list[CloudResource]:
+        resources: list[CloudResource] = []
+        try:
+            paginator = self._ec2.get_paginator("describe_network_interfaces")
+            for page in paginator.paginate():
+                for eni in page.get("NetworkInterfaces", []):
+                    resources.append(self._network_interface_to_cloud_resource(eni))
+        except Exception as e:
+            logger.error(f"Error listing network interfaces: {e}")
+            raise
+        return resources
+
+    def _get_network_interface(self, eni_id: str) -> CloudResource | None:
+        try:
+            resp = self._ec2.describe_network_interfaces(NetworkInterfaceIds=[eni_id])
+            enis = resp.get("NetworkInterfaces", [])
+            if enis:
+                return self._network_interface_to_cloud_resource(enis[0])
+        except Exception:
+            pass
+        return None
+
+    def _network_interface_to_cloud_resource(self, eni: Mapping[str, Any]) -> CloudResource:
+        eni_id = eni["NetworkInterfaceId"]
+        tags = self._extract_tags(eni)
+        sg_ids = [g.get("GroupId") for g in eni.get("Groups", []) if g.get("GroupId")]
+        attrs: dict[str, Any] = {
+            "id": eni_id,
+            "subnet_id": eni.get("SubnetId"),
+            "vpc_id": eni.get("VpcId"),
+            "private_ip": eni.get("PrivateIpAddress"),
+            "security_groups": sorted(sg_ids),
+            "description": eni.get("Description"),
+            "source_dest_check": eni.get("SourceDestCheck", True),
+            "tags": tags,
+        }
+        return CloudResource(
+            resource_id=eni_id,
+            resource_type="aws_network_interface",
+            arn=f"arn:aws:ec2:{self._region}::network-interface/{eni_id}",
+            region=self._region,
+            attributes=attrs,
+            tags=tags,
+        )
 
     # ── Helpers ──────────────────────────────────────────────
 

--- a/src/driftsentry/providers/aws/resources/rds.py
+++ b/src/driftsentry/providers/aws/resources/rds.py
@@ -37,8 +37,8 @@ class RDSScanner(ResourceScanner):
 
         try:
             cluster_paginator = self._rds.get_paginator("describe_db_clusters")
-            for page in cluster_paginator.paginate():
-                for cluster in page.get("DBClusters", []):
+            for cluster_page in cluster_paginator.paginate():
+                for cluster in cluster_page.get("DBClusters", []):
                     resources.append(self._cluster_to_cloud_resource(cluster))
         except ClientError:
             pass
@@ -55,8 +55,8 @@ class RDSScanner(ResourceScanner):
             pass
 
         try:
-            resp = self._rds.describe_db_clusters(DBClusterIdentifier=resource_id)
-            clusters = resp.get("DBClusters", [])
+            cluster_resp = self._rds.describe_db_clusters(DBClusterIdentifier=resource_id)
+            clusters = cluster_resp.get("DBClusters", [])
             if clusters:
                 return self._cluster_to_cloud_resource(clusters[0])
         except ClientError:

--- a/src/driftsentry/providers/aws/resources/rds.py
+++ b/src/driftsentry/providers/aws/resources/rds.py
@@ -25,7 +25,7 @@ class RDSScanner(ResourceScanner):
 
     @property
     def resource_types(self) -> list[str]:
-        return ["aws_db_instance"]
+        return ["aws_db_instance", "aws_rds_cluster"]
 
     def list_all(self) -> list[CloudResource]:
         resources: list[CloudResource] = []
@@ -34,6 +34,14 @@ class RDSScanner(ResourceScanner):
         for page in paginator.paginate():
             for db in page.get("DBInstances", []):
                 resources.append(self._db_to_cloud_resource(db))
+
+        try:
+            cluster_paginator = self._rds.get_paginator("describe_db_clusters")
+            for page in cluster_paginator.paginate():
+                for cluster in page.get("DBClusters", []):
+                    resources.append(self._cluster_to_cloud_resource(cluster))
+        except ClientError:
+            pass
 
         return resources
 
@@ -45,6 +53,15 @@ class RDSScanner(ResourceScanner):
                 return self._db_to_cloud_resource(instances[0])
         except ClientError:
             pass
+
+        try:
+            resp = self._rds.describe_db_clusters(DBClusterIdentifier=resource_id)
+            clusters = resp.get("DBClusters", [])
+            if clusters:
+                return self._cluster_to_cloud_resource(clusters[0])
+        except ClientError:
+            pass
+
         return None
 
     def normalize(self, raw: dict[str, Any]) -> dict[str, Any]:
@@ -96,3 +113,35 @@ class RDSScanner(ResourceScanner):
             return {t["Key"]: t["Value"] for t in resp.get("TagList", [])}
         except ClientError:
             return {}
+
+    def _cluster_to_cloud_resource(self, cluster: Mapping[str, Any]) -> CloudResource:
+        sg_ids = [
+            sg["VpcSecurityGroupId"]
+            for sg in cluster.get("VpcSecurityGroups", [])
+            if sg.get("Status") == "active"
+        ]
+
+        return CloudResource(
+            resource_id=cluster["DBClusterIdentifier"],
+            resource_type="aws_rds_cluster",
+            arn=cluster.get("DBClusterArn"),
+            region=self._region,
+            attributes={
+                "id": cluster.get("DBClusterIdentifier"),
+                "cluster_identifier": cluster.get("DBClusterIdentifier"),
+                "engine": cluster.get("Engine"),
+                "engine_version": cluster.get("EngineVersion"),
+                "database_name": cluster.get("DatabaseName"),
+                "storage_encrypted": cluster.get("StorageEncrypted", False),
+                "kms_key_id": cluster.get("KmsKeyId"),
+                "vpc_security_group_ids": sorted(sg_ids),
+                "db_subnet_group_name": cluster.get("DBSubnetGroup"),
+                "backup_retention_period": cluster.get("BackupRetentionPeriod", 1),
+                "deletion_protection": cluster.get("DeletionProtection", False),
+                "iam_database_authentication_enabled": cluster.get(
+                    "IAMDatabaseAuthenticationEnabled", False
+                ),
+                "copy_tags_to_snapshot": cluster.get("CopyTagsToSnapshot", False),
+            },
+            tags=self._get_tags(cluster.get("DBClusterArn", "")),
+        )

--- a/src/driftsentry/providers/aws/target.py
+++ b/src/driftsentry/providers/aws/target.py
@@ -49,6 +49,11 @@ class TargetResolver:
         accounts: list[AccountConfig] | None = None,
         role_arn_template: str | None = None,
     ) -> None:
+        # Normalize singular region 'all' into regions list
+        if region and region.strip().lower() in ("all", "all-regions"):
+            regions = (regions or []) + [region.strip()]
+            region = None
+
         self._region = region
         self._regions = [r.strip() for r in (regions or []) if r and r.strip()]
         self._profile = profile

--- a/src/driftsentry/resources/aws/aws_efs_file_system.yaml
+++ b/src/driftsentry/resources/aws/aws_efs_file_system.yaml
@@ -1,0 +1,35 @@
+terraform_type: "aws_efs_file_system"
+service: "efs"
+description: "Amazon Elastic File System (EFS)"
+
+discovery:
+  list_operation: "describe_file_systems"
+  result_path: "FileSystems[]"
+  id_field: "FileSystemId"
+
+id_prefix_hints:
+  - "fs-"
+
+attributes:
+  creation_token: "CreationToken"
+  encrypted: "Encrypted"
+  kms_key_id: "KmsKeyId"
+  performance_mode: "PerformanceMode"
+  throughput_mode: "ThroughputMode"
+  provisioned_throughput_in_mibps: "ProvisionedThroughputInMibps"
+  number_of_mount_targets: "NumberOfMountTargets"
+  size_in_bytes: "SizeInBytes.Value"
+
+security_critical:
+  - "encrypted"
+  - "kms_key_id"
+
+noise_attributes:
+  - "size_in_bytes"
+  - "number_of_mount_targets"
+
+cloudtrail_events:
+  - "CreateFileSystem"
+  - "DeleteFileSystem"
+  - "UpdateFileSystem"
+  - "PutLifecycleConfiguration"

--- a/src/driftsentry/resources/aws/aws_eks_cluster.yaml
+++ b/src/driftsentry/resources/aws/aws_eks_cluster.yaml
@@ -1,0 +1,43 @@
+terraform_type: "aws_eks_cluster"
+service: "eks"
+description: "Amazon Elastic Kubernetes Service (EKS) Cluster"
+
+discovery:
+  list_operation: "list_clusters"
+  result_path: "clusters[]"
+  id_field: "@"
+  describe_operation: "describe_cluster"
+  describe_params:
+    name: "{id}"
+  attributes_path: "cluster"
+
+id_prefix_hints:
+  - "arn:aws:eks:"
+
+attributes:
+  name: "name"
+  arn: "arn"
+  version: "version"
+  role_arn: "roleArn"
+  endpoint: "endpoint"
+  platform_version: "platformVersion"
+  status: "status"
+  subnet_ids: "resourcesVpcConfig.subnetIds"
+  security_group_ids: "resourcesVpcConfig.securityGroupIds"
+  endpoint_public_access: "resourcesVpcConfig.endpointPublicAccess"
+  endpoint_private_access: "resourcesVpcConfig.endpointPrivateAccess"
+
+security_critical:
+  - "endpoint_public_access"
+  - "role_arn"
+  - "security_group_ids"
+
+noise_attributes:
+  - "platform_version"
+  - "endpoint"
+
+cloudtrail_events:
+  - "CreateCluster"
+  - "DeleteCluster"
+  - "UpdateClusterVersion"
+  - "UpdateClusterConfig"

--- a/src/driftsentry/resources/aws/aws_lb.yaml
+++ b/src/driftsentry/resources/aws/aws_lb.yaml
@@ -1,0 +1,37 @@
+terraform_type: "aws_lb"
+service: "elbv2"
+description: "Application / Network Load Balancer (ELBv2)"
+
+discovery:
+  list_operation: "describe_load_balancers"
+  result_path: "LoadBalancers[]"
+  id_field: "LoadBalancerArn"
+
+id_prefix_hints:
+  - "arn:aws:elasticloadbalancing:"
+
+attributes:
+  name: "LoadBalancerName"
+  arn: "LoadBalancerArn"
+  dns_name: "DNSName"
+  load_balancer_type: "Type"
+  scheme: "Scheme"
+  vpc_id: "VpcId"
+  ip_address_type: "IpAddressType"
+  security_groups: "SecurityGroups"
+  subnets: "AvailabilityZones[].SubnetId"
+
+security_critical:
+  - "security_groups"
+  - "scheme"
+  - "subnets"
+
+noise_attributes:
+  - "dns_name"
+
+cloudtrail_events:
+  - "CreateLoadBalancer"
+  - "DeleteLoadBalancer"
+  - "ModifyLoadBalancerAttributes"
+  - "SetSecurityGroups"
+  - "SetSubnets"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -166,3 +166,24 @@ def test_last_scan_result_persists_between_invocations(
 
     assert loaded is not None
     assert loaded.scan_id == "persisted"
+
+
+def test_cli_main_entrypoint_function() -> None:
+    from driftsentry.cli.main import main
+
+    assert callable(main)
+
+
+def test_cli_module_execution() -> None:
+    import subprocess
+    import sys
+
+    res = subprocess.run(
+        [sys.executable, "-m", "driftsentry", "version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert res.returncode == 0
+    assert "DriftSentry" in res.stdout
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -186,4 +186,3 @@ def test_cli_module_execution() -> None:
     )
     assert res.returncode == 0
     assert "DriftSentry" in res.stdout
-

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -1,0 +1,226 @@
+"""Unit tests for the driftsentry discover command and engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from driftsentry.cli.main import app
+from driftsentry.core.models import CloudResource
+from driftsentry.discovery.engine import DiscoveryEngine
+from driftsentry.discovery.models import DiscoveryResult
+from driftsentry.discovery.table import DiscoveryTableFormatter
+from driftsentry.providers.base import CloudProvider
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_cloud_resources() -> list[CloudResource]:
+    return [
+        CloudResource(
+            resource_id="i-0123456789abcdef0",
+            resource_type="aws_instance",
+            region="us-east-1",
+            account_id="123456789012",
+            account_name="production",
+            tags={"Name": "web-server-1", "Env": "prod"},
+            attributes={"instance_type": "t3.micro"},
+        ),
+        CloudResource(
+            resource_id="my-data-bucket",
+            resource_type="aws_s3_bucket",
+            arn="arn:aws:s3:::my-data-bucket",
+            region="us-east-1",
+            account_id="123456789012",
+            account_name="production",
+            tags={"Name": "my-data-bucket"},
+            attributes={"bucket": "my-data-bucket"},
+        ),
+    ]
+
+
+def test_cli_discover_help() -> None:
+    """Test that driftsentry discover --help displays proper command help."""
+    result = runner.invoke(app, ["discover", "--help"])
+    assert result.exit_code == 0
+    assert "Discover and list live cloud resources" in result.stdout
+    assert "--region" in result.stdout
+    assert "--regions" in result.stdout
+    assert "--accounts" in result.stdout
+    assert "--include-types" in result.stdout
+    assert "--exclude-types" in result.stdout
+    assert "--output" in result.stdout
+    assert "--save" in result.stdout
+
+
+def test_cli_discover_table_output(mock_cloud_resources: list[CloudResource]) -> None:
+    """Test running discover with mocked AWS provider returning resources."""
+    mock_provider = MagicMock(spec=CloudProvider)
+    mock_provider.provider_name = "aws"
+    mock_provider.scanned_regions = ["us-east-1"]
+    mock_provider.scanned_accounts = ["123456789012"]
+    mock_provider.supported_resource_types.return_value = ["aws_instance", "aws_s3_bucket"]
+
+    def list_side_effect(rtype: str) -> list[CloudResource]:
+        return [r for r in mock_cloud_resources if r.resource_type == rtype]
+
+    mock_provider.list_resources.side_effect = list_side_effect
+
+    with patch("driftsentry.cli.discover.AWSProvider", return_value=mock_provider):
+        result = runner.invoke(app, ["discover", "--region", "us-east-1"])
+        assert result.exit_code == 0
+        assert "Discovered: 2 resources" in result.stdout
+        assert "aws_instance" in result.stdout
+        assert "i-0123456789abcdef0" in result.stdout
+        assert "my-data-bucket" in result.stdout
+
+
+def test_cli_discover_json_and_save(
+    tmp_path: Path, mock_cloud_resources: list[CloudResource]
+) -> None:
+    """Test JSON output format and saving to file."""
+    mock_provider = MagicMock(spec=CloudProvider)
+    mock_provider.provider_name = "aws"
+    mock_provider.scanned_regions = ["us-east-1"]
+    mock_provider.scanned_accounts = ["123456789012"]
+    mock_provider.supported_resource_types.return_value = ["aws_instance"]
+    mock_provider.list_resources.return_value = [mock_cloud_resources[0]]
+
+    save_file = tmp_path / "discovered.json"
+
+    with patch("driftsentry.cli.discover.AWSProvider", return_value=mock_provider):
+        result = runner.invoke(
+            app,
+            [
+                "discover",
+                "--region",
+                "us-east-1",
+                "-o",
+                "json",
+                "--save",
+                str(save_file),
+            ],
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.stdout)
+        assert parsed["total_resources"] == 1
+        assert "aws_instance" in parsed["resources_by_type"]
+
+        assert save_file.exists()
+        saved_data = json.loads(save_file.read_text())
+        assert saved_data["total_resources"] == 1
+
+
+def test_cli_discover_multi_region_and_account_flags() -> None:
+    """Test that CLI passes multi-region and multi-account configurations to AWSProvider."""
+    with patch("driftsentry.cli.discover.AWSProvider") as mock_cls:
+        instance = MagicMock()
+        instance.provider_name = "aws"
+        instance.scanned_regions = ["us-east-1", "us-west-2"]
+        instance.scanned_accounts = ["111122223333", "prod-profile"]
+        instance.supported_resource_types.return_value = []
+        mock_cls.return_value = instance
+
+        result = runner.invoke(
+            app,
+            [
+                "discover",
+                "--regions",
+                "us-east-1,us-west-2",
+                "--accounts",
+                "111122223333,prod-profile",
+                "--role-arn-template",
+                "arn:aws:iam::{account_id}:role/DriftSentryScan",
+                "--concurrency",
+                "8",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_cls.assert_called_once()
+        _, kwargs = mock_cls.call_args
+        assert kwargs["regions"] == ["us-east-1", "us-west-2"]
+        assert len(kwargs["accounts"]) == 2
+        assert kwargs["accounts"][0].id == "111122223333"
+        assert kwargs["accounts"][1].name == "prod-profile"
+        assert kwargs["role_arn_template"] == "arn:aws:iam::{account_id}:role/DriftSentryScan"
+        assert kwargs["concurrency"] == 8
+
+
+def test_cli_discover_unsupported_provider() -> None:
+    """Test error when specifying an unsupported provider."""
+    result = runner.invoke(app, ["discover", "--provider", "gcp"])
+    assert result.exit_code == 1
+    assert "Unsupported provider: gcp" in result.stdout
+
+
+def test_discovery_engine_type_filtering(mock_cloud_resources: list[CloudResource]) -> None:
+    """Test filtering of resource types in DiscoveryEngine."""
+    mock_provider = MagicMock(spec=CloudProvider)
+    mock_provider.provider_name = "aws"
+    mock_provider.supported_resource_types.return_value = [
+        "aws_instance",
+        "aws_s3_bucket",
+        "aws_security_group",
+    ]
+
+    engine = DiscoveryEngine(
+        provider=mock_provider,
+        include_types=["aws_instance", "aws_s3_bucket"],
+        exclude_types=["aws_instance"],
+    )
+
+    types = engine.get_scan_types()
+    assert types == ["aws_s3_bucket"]
+
+
+def test_discovery_engine_handles_errors() -> None:
+    """Test that DiscoveryEngine records errors and continues scanning."""
+    mock_provider = MagicMock(spec=CloudProvider)
+    mock_provider.provider_name = "aws"
+    mock_provider.supported_resource_types.return_value = ["aws_instance", "aws_s3_bucket"]
+
+    def list_side_effect(rtype: str) -> list[CloudResource]:
+        if rtype == "aws_instance":
+            raise RuntimeError("AccessDenied for EC2")
+        return [
+            CloudResource(
+                resource_id="bucket-1",
+                resource_type="aws_s3_bucket",
+            )
+        ]
+
+    mock_provider.list_resources.side_effect = list_side_effect
+
+    engine = DiscoveryEngine(provider=mock_provider)
+    result = engine.discover(show_progress=False)
+
+    assert result.total_resources == 1
+    assert len(result.errors) == 1
+    assert "AccessDenied for EC2" in result.errors[0]
+    assert "aws_s3_bucket" in result.resources_by_type
+
+
+def test_discovery_table_formatter_verbose(mock_cloud_resources: list[CloudResource]) -> None:
+    """Test rendering table formatter in verbose mode."""
+    result = DiscoveryResult(
+        scan_id="test-123",
+        provider="aws",
+        regions=["us-east-1"],
+        accounts=["123456789012", "987654321098"],
+        total_resources=len(mock_cloud_resources),
+        resources_by_type={
+            "aws_instance": [mock_cloud_resources[0]],
+            "aws_s3_bucket": [mock_cloud_resources[1]],
+        },
+        duration_seconds=1.23,
+        errors=["Minor warning"],
+    )
+
+    formatter = DiscoveryTableFormatter(verbose=True)
+    # Should execute without errors
+    formatter.render(result)

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -46,16 +46,19 @@ def mock_cloud_resources() -> list[CloudResource]:
 
 def test_cli_discover_help() -> None:
     """Test that driftsentry discover --help displays proper command help."""
+    import re
+
     result = runner.invoke(app, ["discover", "--help"])
     assert result.exit_code == 0
-    assert "Discover and list live cloud resources" in result.stdout
-    assert "--region" in result.stdout
-    assert "--regions" in result.stdout
-    assert "--accounts" in result.stdout
-    assert "--include-types" in result.stdout
-    assert "--exclude-types" in result.stdout
-    assert "--output" in result.stdout
-    assert "--save" in result.stdout
+    clean_stdout = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", result.stdout)
+    assert "Discover and list live cloud resources" in clean_stdout
+    assert "--region" in clean_stdout
+    assert "--regions" in clean_stdout
+    assert "--accounts" in clean_stdout
+    assert "--include-types" in clean_stdout
+    assert "--exclude-types" in clean_stdout
+    assert "--output" in clean_stdout
+    assert "--save" in clean_stdout
 
 
 def test_cli_discover_table_output(mock_cloud_resources: list[CloudResource]) -> None:

--- a/tests/unit/test_ebs_scanner.py
+++ b/tests/unit/test_ebs_scanner.py
@@ -1,0 +1,218 @@
+"""Unit tests for EBS, Snapshots, AMIs, RDS clusters, and EFS scanners."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from driftsentry.providers.aws.catalog import ResourceCatalog
+from driftsentry.providers.aws.declarative import GenericAWSDeclarativeScanner
+from driftsentry.providers.aws.resources.ebs import EBSScanner
+from driftsentry.providers.aws.resources.rds import RDSScanner
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    session = MagicMock()
+    return session
+
+
+def test_ebs_scanner_supported_types(mock_session: MagicMock) -> None:
+    scanner = EBSScanner(mock_session, "us-east-1")
+    assert sorted(scanner.resource_types) == ["aws_ami", "aws_ebs_snapshot", "aws_ebs_volume"]
+
+
+def test_ebs_volume_listing_and_get(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_vol = {
+        "VolumeId": "vol-0123456789abcdef0",
+        "AvailabilityZone": "us-east-1a",
+        "Size": 100,
+        "VolumeType": "gp3",
+        "Iops": 3000,
+        "Throughput": 125,
+        "Encrypted": True,
+        "KmsKeyId": "arn:aws:kms:us-east-1:123456789012:key/sample-key",
+        "Tags": [{"Key": "Name", "Value": "data-vol"}],
+    }
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Volumes": [sample_vol]}]
+    mock_ec2.get_paginator.return_value = paginator
+
+    scanner = EBSScanner(mock_session, "us-east-1")
+    volumes = scanner._list_volumes()
+    assert len(volumes) == 1
+    vol = volumes[0]
+    assert vol.resource_id == "vol-0123456789abcdef0"
+    assert vol.resource_type == "aws_ebs_volume"
+    assert vol.attributes["size"] == 100
+    assert vol.attributes["encrypted"] is True
+    assert vol.tags["Name"] == "data-vol"
+
+    # Test get_by_id
+    mock_ec2.describe_volumes.return_value = {"Volumes": [sample_vol]}
+    fetched = scanner.get_by_id("vol-0123456789abcdef0")
+    assert fetched is not None
+    assert fetched.resource_id == "vol-0123456789abcdef0"
+
+
+def test_ebs_snapshot_listing_filters_self(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_snap = {
+        "SnapshotId": "snap-0123456789abcdef0",
+        "VolumeId": "vol-0123456789abcdef0",
+        "VolumeSize": 100,
+        "Description": "Daily backup",
+        "Encrypted": True,
+        "OwnerId": "123456789012",
+        "Tags": [{"Key": "Environment", "Value": "prod"}],
+    }
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"Snapshots": [sample_snap]}]
+    mock_ec2.get_paginator.return_value = paginator
+
+    scanner = EBSScanner(mock_session, "us-east-1")
+    snapshots = scanner._list_snapshots()
+
+    # Crucial assertion: paginator was invoked with OwnerIds=['self']
+    mock_ec2.get_paginator.assert_called_with("describe_snapshots")
+    paginator.paginate.assert_called_with(OwnerIds=["self"])
+
+    assert len(snapshots) == 1
+    snap = snapshots[0]
+    assert snap.resource_id == "snap-0123456789abcdef0"
+    assert snap.resource_type == "aws_ebs_snapshot"
+    assert snap.attributes["volume_size"] == 100
+    assert snap.tags["Environment"] == "prod"
+
+
+def test_ami_listing_filters_self(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_img = {
+        "ImageId": "ami-0123456789abcdef0",
+        "Name": "custom-golden-image",
+        "Description": "Ubuntu hardened base",
+        "Architecture": "x86_64",
+        "ImageType": "machine",
+        "RootDeviceName": "/dev/sda1",
+        "VirtualizationType": "hvm",
+        "Tags": [{"Key": "BakedBy", "Value": "Packer"}],
+    }
+
+    mock_ec2.describe_images.return_value = {"Images": [sample_img]}
+
+    scanner = EBSScanner(mock_session, "us-east-1")
+    images = scanner._list_images()
+
+    # Crucial assertion: describe_images called with Owners=['self']
+    mock_ec2.describe_images.assert_called_with(Owners=["self"])
+
+    assert len(images) == 1
+    img = images[0]
+    assert img.resource_id == "ami-0123456789abcdef0"
+    assert img.resource_type == "aws_ami"
+    assert img.attributes["name"] == "custom-golden-image"
+    assert img.tags["BakedBy"] == "Packer"
+
+
+def test_rds_cluster_scanner(mock_session: MagicMock) -> None:
+    mock_rds = MagicMock()
+    mock_session.client.return_value = mock_rds
+
+    # Mock DB instance paginator
+    inst_paginator = MagicMock()
+    inst_paginator.paginate.return_value = [
+        {
+            "DBInstances": [
+                {
+                    "DBInstanceIdentifier": "postgres-prod",
+                    "Engine": "postgres",
+                    "DBInstanceClass": "db.t3.medium",
+                }
+            ]
+        }
+    ]
+
+    # Mock DB cluster paginator
+    cluster_paginator = MagicMock()
+    cluster_paginator.paginate.return_value = [
+        {
+            "DBClusters": [
+                {
+                    "DBClusterIdentifier": "aurora-pg-cluster",
+                    "Engine": "aurora-postgresql",
+                    "DatabaseName": "appdb",
+                    "StorageEncrypted": True,
+                }
+            ]
+        }
+    ]
+
+    def paginator_side_effect(op: str) -> MagicMock:
+        if op == "describe_db_instances":
+            return inst_paginator
+        elif op == "describe_db_clusters":
+            return cluster_paginator
+        return MagicMock()
+
+    mock_rds.get_paginator.side_effect = paginator_side_effect
+
+    scanner = RDSScanner(mock_session, "us-east-1")
+    assert "aws_rds_cluster" in scanner.resource_types
+
+    all_rds = scanner.list_all()
+    types = [r.resource_type for r in all_rds]
+    assert "aws_db_instance" in types
+    assert "aws_rds_cluster" in types
+
+    cluster_res = next(r for r in all_rds if r.resource_type == "aws_rds_cluster")
+    assert cluster_res.resource_id == "aurora-pg-cluster"
+    assert cluster_res.attributes["engine"] == "aurora-postgresql"
+
+
+def test_efs_declarative_scanner(mock_session: MagicMock) -> None:
+    catalog = ResourceCatalog()
+    specs = catalog.load_all()
+    assert "aws_efs_file_system" in specs
+
+    efs_spec = specs["aws_efs_file_system"]
+    mock_efs = MagicMock()
+    mock_session.client.return_value = mock_efs
+
+    mock_efs.can_paginate.return_value = True
+    efs_paginator = MagicMock()
+    efs_paginator.paginate.return_value = [
+        {
+            "FileSystems": [
+                {
+                    "FileSystemId": "fs-01234567",
+                    "CreationToken": "app-data-efs",
+                    "Encrypted": True,
+                    "PerformanceMode": "generalPurpose",
+                    "ThroughputMode": "bursting",
+                    "Tags": [{"Key": "Name", "Value": "app-shared-storage"}],
+                }
+            ]
+        }
+    ]
+    mock_efs.get_paginator.return_value = efs_paginator
+
+    scanner = GenericAWSDeclarativeScanner(mock_session, "us-east-1", efs_spec)
+    assert scanner.resource_types == ["aws_efs_file_system"]
+
+    resources = scanner.list_all()
+    assert len(resources) == 1
+    efs = resources[0]
+    assert efs.resource_id == "fs-01234567"
+    assert efs.attributes["creation_token"] == "app-data-efs"
+    assert efs.attributes["encrypted"] is True
+    assert efs.tags["Name"] == "app-shared-storage"

--- a/tests/unit/test_multi_account_region.py
+++ b/tests/unit/test_multi_account_region.py
@@ -93,6 +93,35 @@ def test_target_resolver_all_regions_expansion() -> None:
         assert [t.region for t in targets] == ["ap-southeast-1", "us-east-1", "us-west-2"]
 
 
+def test_target_resolver_singular_region_all_expansion() -> None:
+    """Verify singular region='all' expands properly and never yields region 'all'."""
+    resolver = TargetResolver(region="all")
+    with patch("driftsentry.providers.aws.provider.AWSProvider._create_session") as mock_sess:
+        mock_instance = MagicMock()
+        mock_ec2 = MagicMock()
+        mock_ec2.describe_regions.return_value = {
+            "Regions": [
+                {"RegionName": "us-east-1"},
+                {"RegionName": "us-west-2"},
+            ]
+        }
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {"Account": "123456789012"}
+
+        def client_side_effect(service: str, **kwargs: object) -> MagicMock:
+            if service == "ec2":
+                return mock_ec2
+            return mock_sts
+
+        mock_instance.client.side_effect = client_side_effect
+        mock_sess.return_value = mock_instance
+
+        targets = resolver.resolve_targets()
+        assert len(targets) == 2
+        assert "all" not in [t.region for t in targets]
+        assert [t.region for t in targets] == ["us-east-1", "us-west-2"]
+
+
 def test_target_resolver_multi_account_and_template() -> None:
     """Test multi-account resolution with role_arn_template."""
     accounts = [

--- a/tests/unit/test_network_and_cluster_scanners.py
+++ b/tests/unit/test_network_and_cluster_scanners.py
@@ -1,0 +1,242 @@
+"""Unit tests for Elastic IPs, Key Pairs, Network Interfaces, Load Balancers, and EKS scanners."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from driftsentry.providers.aws.catalog import ResourceCatalog
+from driftsentry.providers.aws.declarative import GenericAWSDeclarativeScanner
+from driftsentry.providers.aws.resources.ec2 import EC2Scanner
+
+
+@pytest.fixture
+def mock_session() -> MagicMock:
+    session = MagicMock()
+    return session
+
+
+def test_ec2_scanner_supported_types(mock_session: MagicMock) -> None:
+    scanner = EC2Scanner(mock_session, "us-east-1")
+    expected = {
+        "aws_instance",
+        "aws_security_group",
+        "aws_vpc",
+        "aws_subnet",
+        "aws_eip",
+        "aws_key_pair",
+        "aws_network_interface",
+    }
+    assert expected.issubset(set(scanner.resource_types))
+
+
+def test_eip_listing_and_get(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_eip = {
+        "AllocationId": "eipalloc-0123456789abcdef0",
+        "PublicIp": "54.210.10.20",
+        "Domain": "vpc",
+        "InstanceId": "i-0123456789abcdef0",
+        "NetworkInterfaceId": "eni-0123456789abcdef0",
+        "Tags": [{"Key": "Name", "Value": "bastion-ip"}],
+    }
+
+    mock_ec2.describe_addresses.return_value = {"Addresses": [sample_eip]}
+
+    scanner = EC2Scanner(mock_session, "us-east-1")
+    eips = scanner._list_eips()
+    assert len(eips) == 1
+    eip = eips[0]
+    assert eip.resource_id == "eipalloc-0123456789abcdef0"
+    assert eip.resource_type == "aws_eip"
+    assert eip.attributes["public_ip"] == "54.210.10.20"
+    assert eip.attributes["instance"] == "i-0123456789abcdef0"
+    assert eip.attributes["domain"] == "vpc"
+    assert eip.tags["Name"] == "bastion-ip"
+
+    # Test get_by_id by allocation ID
+    fetched = scanner.get_by_id("eipalloc-0123456789abcdef0")
+    assert fetched is not None
+    assert fetched.resource_id == "eipalloc-0123456789abcdef0"
+
+    # Test get_by_id by public IP address
+    fetched_by_ip = scanner.get_by_id("54.210.10.20")
+    assert fetched_by_ip is not None
+    assert fetched_by_ip.resource_id == "eipalloc-0123456789abcdef0"
+
+
+def test_key_pair_listing_and_get(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_kp = {
+        "KeyPairId": "key-0123456789abcdef0",
+        "KeyName": "prod-ssh-key",
+        "KeyFingerprint": "11:22:33:44:55:66:77:88:99:00:aa:bb:cc:dd:ee:ff",
+        "KeyType": "ed25519",
+        "Tags": [{"Key": "Environment", "Value": "Production"}],
+    }
+
+    mock_ec2.describe_key_pairs.return_value = {"KeyPairs": [sample_kp]}
+
+    scanner = EC2Scanner(mock_session, "us-east-1")
+    key_pairs = scanner._list_key_pairs()
+    assert len(key_pairs) == 1
+    kp = key_pairs[0]
+    assert kp.resource_id == "prod-ssh-key"
+    assert kp.resource_type == "aws_key_pair"
+    assert kp.attributes["key_name"] == "prod-ssh-key"
+    assert kp.attributes["key_pair_id"] == "key-0123456789abcdef0"
+    assert kp.attributes["key_type"] == "ed25519"
+    assert kp.tags["Environment"] == "Production"
+
+    # Test get_by_id with key ID
+    fetched = scanner.get_by_id("key-0123456789abcdef0")
+    assert fetched is not None
+    assert fetched.resource_id == "prod-ssh-key"
+
+    # Test get_by_id with key name
+    fetched_by_name = scanner.get_by_id("prod-ssh-key")
+    assert fetched_by_name is not None
+    assert fetched_by_name.attributes["key_name"] == "prod-ssh-key"
+
+
+def test_network_interface_listing_and_get(mock_session: MagicMock) -> None:
+    mock_ec2 = MagicMock()
+    mock_session.client.return_value = mock_ec2
+
+    sample_eni = {
+        "NetworkInterfaceId": "eni-0123456789abcdef0",
+        "SubnetId": "subnet-12345678",
+        "VpcId": "vpc-12345678",
+        "PrivateIpAddress": "10.0.1.50",
+        "Description": "Primary ENI",
+        "Groups": [{"GroupId": "sg-12345678", "GroupName": "default"}],
+        "Tags": [{"Key": "Role", "Value": "web"}],
+    }
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"NetworkInterfaces": [sample_eni]}]
+    mock_ec2.get_paginator.return_value = paginator
+
+    scanner = EC2Scanner(mock_session, "us-east-1")
+    enis = scanner._list_network_interfaces()
+    assert len(enis) == 1
+    eni = enis[0]
+    assert eni.resource_id == "eni-0123456789abcdef0"
+    assert eni.resource_type == "aws_network_interface"
+    assert eni.attributes["private_ip"] == "10.0.1.50"
+    assert eni.attributes["subnet_id"] == "subnet-12345678"
+    assert eni.attributes["security_groups"] == ["sg-12345678"]
+    assert eni.tags["Role"] == "web"
+
+    # Test get_by_id
+    mock_ec2.describe_network_interfaces.return_value = {"NetworkInterfaces": [sample_eni]}
+    fetched = scanner.get_by_id("eni-0123456789abcdef0")
+    assert fetched is not None
+    assert fetched.resource_id == "eni-0123456789abcdef0"
+
+
+def test_catalog_loads_lb_and_eks() -> None:
+    catalog = ResourceCatalog()
+    definitions = catalog.load_all()
+
+    assert "aws_lb" in definitions
+    lb_def = definitions["aws_lb"]
+    assert lb_def.service == "elbv2"
+    assert lb_def.discovery.list_operation == "describe_load_balancers"
+    assert lb_def.discovery.id_field == "LoadBalancerArn"
+
+    assert "aws_eks_cluster" in definitions
+    eks_def = definitions["aws_eks_cluster"]
+    assert eks_def.service == "eks"
+    assert eks_def.discovery.list_operation == "list_clusters"
+    assert eks_def.discovery.describe_operation == "describe_cluster"
+
+
+def test_declarative_scanner_lb(mock_session: MagicMock) -> None:
+    catalog = ResourceCatalog()
+    defs = catalog.load_all()
+    lb_def = defs["aws_lb"]
+
+    mock_elbv2 = MagicMock()
+    mock_session.client.return_value = mock_elbv2
+
+    sample_lb = {
+        "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/my-alb/1234567890abcdef",
+        "LoadBalancerName": "my-alb",
+        "DNSName": "my-alb-1234567890.us-east-1.elb.amazonaws.com",
+        "Scheme": "internet-facing",
+        "VpcId": "vpc-12345678",
+        "Type": "application",
+        "State": {"Code": "active"},
+        "SecurityGroups": ["sg-12345678"],
+        "AvailabilityZones": [
+            {"ZoneName": "us-east-1a", "SubnetId": "subnet-11111111"},
+            {"ZoneName": "us-east-1b", "SubnetId": "subnet-22222222"},
+        ],
+        "IpAddressType": "ipv4",
+        "Tags": [{"Key": "Env", "Value": "prod"}],
+    }
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"LoadBalancers": [sample_lb]}]
+    mock_elbv2.get_paginator.return_value = paginator
+
+    scanner = GenericAWSDeclarativeScanner(mock_session, "us-east-1", lb_def)
+    resources = scanner.list_all()
+    assert len(resources) == 1
+    res = resources[0]
+    assert res.resource_id == sample_lb["LoadBalancerArn"]
+    assert res.attributes["name"] == "my-alb"
+    assert res.attributes["load_balancer_type"] == "application"
+    assert res.attributes["scheme"] == "internet-facing"
+    assert res.attributes["security_groups"] == ["sg-12345678"]
+    assert "subnet-11111111" in res.attributes["subnets"]
+    assert res.tags.get("Env") == "prod"
+
+
+def test_declarative_scanner_eks(mock_session: MagicMock) -> None:
+    catalog = ResourceCatalog()
+    defs = catalog.load_all()
+    eks_def = defs["aws_eks_cluster"]
+
+    mock_eks = MagicMock()
+    mock_session.client.return_value = mock_eks
+
+    paginator = MagicMock()
+    paginator.paginate.return_value = [{"clusters": ["my-prod-cluster"]}]
+    mock_eks.get_paginator.return_value = paginator
+
+    mock_eks.describe_cluster.return_value = {
+        "cluster": {
+            "name": "my-prod-cluster",
+            "arn": "arn:aws:eks:us-east-1:123456789012:cluster/my-prod-cluster",
+            "version": "1.30",
+            "endpoint": "https://ABCDEF123456.gr7.us-east-1.eks.amazonaws.com",
+            "roleArn": "arn:aws:iam::123456789012:role/eksClusterRole",
+            "resourcesVpcConfig": {
+                "subnetIds": ["subnet-1111", "subnet-2222"],
+                "securityGroupIds": ["sg-3333"],
+                "clusterSecurityGroupId": "sg-4444",
+                "endpointPublicAccess": True,
+                "endpointPrivateAccess": False,
+            },
+            "tags": {"Owner": "DevOps"},
+        }
+    }
+
+    scanner = GenericAWSDeclarativeScanner(mock_session, "us-east-1", eks_def)
+    resources = scanner.list_all()
+    assert len(resources) == 1
+    res = resources[0]
+    assert res.resource_id == "my-prod-cluster"
+    assert res.attributes["name"] == "my-prod-cluster"
+    assert res.attributes["version"] == "1.30"
+    assert res.attributes["role_arn"] == "arn:aws:iam::123456789012:role/eksClusterRole"
+    assert res.attributes["endpoint_public_access"] is True
+    assert res.attributes["subnet_ids"] == ["subnet-1111", "subnet-2222"]
+    assert res.tags.get("Owner") == "DevOps"


### PR DESCRIPTION
## Summary

This PR introduces the **`driftsentry discover`** command to discover and audit live AWS resources without needing an existing IaC state file, and significantly expands DriftSentry's scanner coverage across compute, storage, networking, database, and containers.

### Key Features & Enhancements

1. **Live Resource Discovery CLI (`driftsentry discover`)**
   - Discovers live cloud resources across single or multiple AWS regions.
   - Outputs interactive Rich terminal tables with resource counts, IDs, types, and tags.
   - Ideal for cloud auditing, migration planning, and verifying clean accounts prior to closure.

2. **Expanded AWS Resource Coverage**
   - **Compute & Storage:**
     - EBS Volumes (`aws_ebs_volume`)
     - EBS Snapshots (`aws_ebs_snapshot`)
     - AMIs (`aws_ami`)
     - EFS File Systems (`aws_efs_file_system`)
   - **Networking:**
     - Elastic IPs (`aws_eip`)
     - Key Pairs (`aws_key_pair`)
     - Network Interfaces (`aws_network_interface`)
     - Load Balancers (`aws_lb` via ELBv2)
   - **Database & Containers:**
     - RDS Clusters (`aws_rds_cluster`)
     - EKS Clusters (`aws_eks_cluster`)
   - **CloudTrail Attribution Mappings:** Added mutation events for all new resources.

3. **Platform & CLI Fixes**
   - **Windows Entrypoint:** Added explicit `__main__.py` and callable entry point for Windows PATH execution.
   - **Region Normalization:** Normalized singular `--region all` to prevent Boto3 endpoint connection errors (`*.all.amazonaws.com`).
   - **Declarative Tag Resolution:** Enhanced tag extraction in `GenericAWSDeclarativeScanner` to resolve nested wrapper responses.

### Verification
- **Unit Tests:** 127 tests passing (`pytest tests/unit/`)
- **Linters & Formatting:** Clean (`ruff check .`, `ruff format --check src/ tests/`)