### PR TITLE
feat(filters): add resource exclusion filtering by tags and identifier patterns

### DIFF
--- a/.driftsentry.yaml.example
+++ b/.driftsentry.yaml.example
@@ -86,6 +86,21 @@ filters:
   include_types: []
   # Exclude specific resource types
   exclude_types: []
+  # Exclude resources by tag key-value pairs (supports lists and '*' wildcard)
+  # exclude_tags:
+  #   managed-by:
+  #     - "AFT"
+  #     - "aft"
+  #     - "AWSControlTower"
+  #   CreatedBy: "AFT"
+  #   Environment: "baseline"
+  # Exclude resources by ID, Name, or ARN glob patterns (case-insensitive fnmatch)
+  # exclude_patterns:
+  #   - "*aft*"
+  #   - "*control-tower*"
+  #   - "vpc-default"
+  #   - "*-default-sg"
+  #   - "arn:aws:iam::*:role/aws-service-role/*"
   # Attributes to ignore during diff (noise reduction)
   ignore_attributes:
     - "tags_all"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -96,8 +96,15 @@ notifications:
     - "critical"
     - "high"
 
-# Filter noise
+# Filter noise and exclude baseline resources
 filters:
+  # exclude_tags:
+  #   managed-by: ["AFT", "AWSControlTower"]
+  #   Environment: "baseline"
+  # exclude_patterns:
+  #   - "*aft*"
+  #   - "vpc-default"
+  #   - "*-default-sg"
   ignore_attributes:
     - "tags_all"
     - "arn"
@@ -149,7 +156,38 @@ filters:
 | `monitor.smart_alerts_only`| `boolean`| `true` | Only dispatch notifications (e.g. Slack) for NEW, REGRESSION, or WORSENED drift. |
 | `notifications.slack_webhook_url` | `string` | — | Slack Incoming Webhook URL (supports `${ENV_VAR}` expansion). |
 | `notifications.notify_on` | `list` | `["critical", "high"]` | Drift severity levels that trigger Slack notifications. |
+| `filters.include_types` | `list[string]` | `[]` | Only scan these specific resource types (empty = all). |
+| `filters.exclude_types` | `list[string]` | `[]` | Skip scanning these resource types completely. |
+| `filters.exclude_tags` | `dict[string, string \| list[string]]` | `{}` | Exclude resources matching tag key-values (supports lists and `'*'`). |
+| `filters.exclude_patterns` | `list[string]` | `[]` | Exclude resources matching ID, Name, or ARN glob patterns. |
 | `filters.ignore_attributes` | `list` | `["arn", "id", ...]` | Top-level or nested attributes ignored during diff evaluation. |
+| `filters.ignore_unmanaged_types` | `list[string]` | `[]` | Cloud resource types to exclude from UNMANAGED detection. |
+
+---
+
+### Excluding Account Vending Baselines (AFT / Control Tower)
+
+When scanning or discovering resources in accounts provisioned by AWS Control Tower or Account Factory for Terraform (AFT), baseline infrastructure (default VPCs, AFT management VPCs, baseline IAM roles) can pollute scan results. You can suppress these baseline resources declaratively:
+
+```yaml
+filters:
+  # Exclude by tag
+  exclude_tags:
+    managed-by:
+      - "AFT"
+      - "aft"
+      - "AWSControlTower"
+    Environment: "baseline"
+    Terraform: "*"
+
+  # Exclude by ID, Name tag, or ARN glob pattern
+  exclude_patterns:
+    - "*aft*"
+    - "*control-tower*"
+    - "vpc-default"
+    - "*-default-sg"
+    - "arn:aws:iam::*:role/aws-service-role/*"
+```
 
 ---
 

--- a/src/driftsentry/cli/discover.py
+++ b/src/driftsentry/cli/discover.py
@@ -181,6 +181,7 @@ def discover(
         provider=cloud_provider,
         include_types=resolved_include_types,
         exclude_types=resolved_exclude_types,
+        filters=config.filters,
     )
 
     try:

--- a/src/driftsentry/core/config.py
+++ b/src/driftsentry/core/config.py
@@ -161,6 +161,14 @@ class ScanFilters(BaseModel):
         default_factory=list,
         description="Exclude these resource types from scanning",
     )
+    exclude_tags: dict[str, str | list[str]] = Field(
+        default_factory=dict,
+        description="Exclude resources matching any of these tag key-value pairs (value can be a string or list of matching strings; supports '*' wildcard)",
+    )
+    exclude_patterns: list[str] = Field(
+        default_factory=list,
+        description="Exclude resources whose resource ID, name, or ARN matches any of these glob patterns (case-insensitive fnmatch)",
+    )
     ignore_attributes: list[str] = Field(
         default_factory=lambda: [
             "tags_all",

--- a/src/driftsentry/core/filter.py
+++ b/src/driftsentry/core/filter.py
@@ -1,0 +1,145 @@
+"""Resource filtering utility — checks resources against tag and pattern exclusion rules."""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from driftsentry.core.config import ScanFilters
+    from driftsentry.core.models import CloudResource, ResourceState
+
+
+def _match_pattern(value: str, pattern: str) -> bool:
+    """Check if a string matches a pattern (glob or regex prefixed with 're:')."""
+    if pattern.startswith("re:"):
+        return bool(re.search(pattern[3:], value, re.IGNORECASE))
+    return fnmatch.fnmatch(value.lower(), pattern.lower())
+
+
+def _match_tag(actual_val: str, expected_spec: str | list[str]) -> bool:
+    """Check if an actual tag value matches an expected spec (string or list)."""
+    if expected_spec == "*":
+        return True
+    if isinstance(expected_spec, str):
+        return _match_pattern(actual_val, expected_spec)
+    if isinstance(expected_spec, list):
+        return any(_match_pattern(actual_val, s) for s in expected_spec)
+    return False
+
+
+def is_resource_excluded(resource: CloudResource, filters: ScanFilters | None) -> bool:
+    """Determine whether a live CloudResource should be excluded based on tags or patterns.
+
+    Args:
+        resource: The CloudResource to inspect.
+        filters: The ScanFilters configuration containing exclusion rules.
+
+    Returns:
+        True if the resource matches any exclusion tag or pattern rule; False otherwise.
+    """
+    if filters is None:
+        return False
+
+    # 1. Tag-based exclusion
+    if filters.exclude_tags:
+        tags: dict[str, Any] = dict(resource.tags)
+        if not tags and isinstance(resource.attributes.get("tags"), dict):
+            tags = resource.attributes["tags"]
+        if isinstance(resource.attributes.get("tags_all"), dict):
+            tags.update(resource.attributes["tags_all"])
+
+        lower_tags = {str(k).lower(): str(v) for k, v in tags.items()}
+
+        for rule_key, rule_val in filters.exclude_tags.items():
+            rule_key_lower = rule_key.lower()
+            if rule_key_lower in lower_tags:
+                actual_val = lower_tags[rule_key_lower]
+                if _match_tag(actual_val, rule_val):
+                    return True
+
+    # 2. Pattern-based exclusion (resource_id, name, ARN)
+    if filters.exclude_patterns:
+        candidates: list[str] = [resource.resource_id]
+        if resource.arn:
+            candidates.append(resource.arn)
+
+        name_tag = resource.tags.get("Name") or resource.tags.get("name")
+        if name_tag:
+            candidates.append(name_tag)
+
+        attr_name = resource.attributes.get("name")
+        if isinstance(attr_name, str):
+            candidates.append(attr_name)
+
+        attr_id = resource.attributes.get("id")
+        if isinstance(attr_id, str):
+            candidates.append(attr_id)
+
+        for pattern in filters.exclude_patterns:
+            for candidate in candidates:
+                if candidate and _match_pattern(candidate, pattern):
+                    return True
+
+    return False
+
+
+def is_state_resource_excluded(state_res: ResourceState, filters: ScanFilters | None) -> bool:
+    """Determine whether a ResourceState should be excluded based on tags or patterns.
+
+    Args:
+        state_res: The ResourceState from state file.
+        filters: The ScanFilters configuration containing exclusion rules.
+
+    Returns:
+        True if the state resource matches any exclusion tag or pattern rule; False otherwise.
+    """
+    if filters is None:
+        return False
+
+    # 1. Tag-based exclusion from attributes
+    if filters.exclude_tags:
+        tags: dict[str, Any] = {}
+        if isinstance(state_res.attributes.get("tags"), dict):
+            tags.update(state_res.attributes["tags"])
+        if isinstance(state_res.attributes.get("tags_all"), dict):
+            tags.update(state_res.attributes["tags_all"])
+
+        lower_tags = {str(k).lower(): str(v) for k, v in tags.items()}
+        for rule_key, rule_val in filters.exclude_tags.items():
+            rule_key_lower = rule_key.lower()
+            if rule_key_lower in lower_tags:
+                actual_val = lower_tags[rule_key_lower]
+                if _match_tag(actual_val, rule_val):
+                    return True
+
+    # 2. Pattern-based exclusion
+    if filters.exclude_patterns:
+        candidates: list[str] = [
+            state_res.address,
+            state_res.resource_name,
+        ]
+        if state_res.resource_id:
+            candidates.append(state_res.resource_id)
+
+        arn = state_res.attributes.get("arn")
+        if isinstance(arn, str):
+            candidates.append(arn)
+
+        name = state_res.attributes.get("name")
+        if isinstance(name, str):
+            candidates.append(name)
+
+        tags_dict = state_res.attributes.get("tags")
+        if isinstance(tags_dict, dict):
+            name_tag = tags_dict.get("Name") or tags_dict.get("name")
+            if isinstance(name_tag, str):
+                candidates.append(name_tag)
+
+        for pattern in filters.exclude_patterns:
+            for candidate in candidates:
+                if candidate and _match_pattern(candidate, pattern):
+                    return True
+
+    return False

--- a/src/driftsentry/core/scanner.py
+++ b/src/driftsentry/core/scanner.py
@@ -18,6 +18,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from driftsentry.core.config import DriftSentryConfig
 from driftsentry.core.differ import DriftDiffer
+from driftsentry.core.filter import is_resource_excluded, is_state_resource_excluded
 from driftsentry.core.models import (
     CloudResource,
     DriftItem,
@@ -193,8 +194,13 @@ class DriftScanner:
         for rtype in resource_types:
             try:
                 resources = self._provider.list_resources(rtype)
-                cloud_resources[rtype] = resources
-                logger.debug(f"Found {len(resources)} {rtype} resources in cloud")
+                filtered_resources = [
+                    cr for cr in resources if not is_resource_excluded(cr, self._config.filters)
+                ]
+                cloud_resources[rtype] = filtered_resources
+                logger.debug(
+                    f"Found {len(filtered_resources)} {rtype} resources in cloud (filtered from {len(resources)})"
+                )
             except Exception as e:
                 errors.append(f"Error scanning {rtype}: {e}")
                 logger.error(f"Error scanning {rtype}: {e}")
@@ -226,6 +232,9 @@ class DriftScanner:
 
         # 1. Check each state resource against the cloud
         for state_res in state_resources:
+            if is_state_resource_excluded(state_res, self._config.filters):
+                continue
+
             if state_res.resource_type not in cloud_resources:
                 continue  # Provider doesn't support this type
 
@@ -268,6 +277,9 @@ class DriftScanner:
         state_arns = {r.attributes.get("arn") for r in state_resources if r.attributes.get("arn")}
 
         for key, cloud_res in cloud_lookup.items():
+            if is_resource_excluded(cloud_res, self._config.filters):
+                continue
+
             is_matched_by_id = key in state_ids
             is_matched_by_arn = cloud_res.arn is not None and cloud_res.arn in state_arns
 

--- a/src/driftsentry/discovery/engine.py
+++ b/src/driftsentry/discovery/engine.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import logging
 import time
 import uuid
+from typing import TYPE_CHECKING
 
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from driftsentry.core.filter import is_resource_excluded
 from driftsentry.core.models import CloudResource
 from driftsentry.discovery.models import DiscoveryResult
 from driftsentry.providers.base import CloudProvider
+
+if TYPE_CHECKING:
+    from driftsentry.core.config import ScanFilters
 
 logger = logging.getLogger(__name__)
 
@@ -23,10 +28,12 @@ class DiscoveryEngine:
         provider: CloudProvider,
         include_types: list[str] | None = None,
         exclude_types: list[str] | None = None,
+        filters: ScanFilters | None = None,
     ) -> None:
         self._provider = provider
         self._include_types = set(include_types) if include_types else None
         self._exclude_types = set(exclude_types) if exclude_types else set()
+        self._filters = filters
 
     def get_scan_types(self) -> list[str]:
         """Determine the set of resource types to scan based on filters."""
@@ -71,6 +78,8 @@ class DiscoveryEngine:
                     )
                     try:
                         found = self._provider.list_resources(rtype)
+                        if found and self._filters:
+                            found = [r for r in found if not is_resource_excluded(r, self._filters)]
                         if found:
                             resources_by_type[rtype] = found
                     except Exception as e:
@@ -87,6 +96,8 @@ class DiscoveryEngine:
             for rtype in target_types:
                 try:
                     found = self._provider.list_resources(rtype)
+                    if found and self._filters:
+                        found = [r for r in found if not is_resource_excluded(r, self._filters)]
                     if found:
                         resources_by_type[rtype] = found
                 except Exception as e:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -28,3 +28,31 @@ monitor:
     assert config.monitor.interval_minutes == 15
     assert config.monitor.max_scans == 10
     assert config.monitor.smart_alerts_only is False
+
+
+def test_scan_filters_exclusion_defaults() -> None:
+    config = DriftSentryConfig()
+    assert config.filters.exclude_tags == {}
+    assert config.filters.exclude_patterns == []
+
+
+def test_scan_filters_exclusion_custom_yaml(tmp_path: Path) -> None:
+    yaml_content = """
+filters:
+  exclude_tags:
+    managed-by:
+      - "AFT"
+      - "ControlTower"
+    Environment: "baseline"
+  exclude_patterns:
+    - "*aft*"
+    - "vpc-default"
+"""
+    config_file = tmp_path / ".driftsentry.yaml"
+    config_file.write_text(yaml_content)
+
+    config = load_config(config_file)
+
+    assert config.filters.exclude_tags["managed-by"] == ["AFT", "ControlTower"]
+    assert config.filters.exclude_tags["Environment"] == "baseline"
+    assert config.filters.exclude_patterns == ["*aft*", "vpc-default"]

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -227,3 +227,57 @@ def test_discovery_table_formatter_verbose(mock_cloud_resources: list[CloudResou
     formatter = DiscoveryTableFormatter(verbose=True)
     # Should execute without errors
     formatter.render(result)
+
+
+def test_discovery_engine_with_exclusion_filters() -> None:
+    """Test DiscoveryEngine resource exclusion by tags and patterns."""
+    from driftsentry.core.config import ScanFilters
+
+    mock_provider = MagicMock(spec=CloudProvider)
+    mock_provider.provider_name = "aws"
+    mock_provider.supported_resource_types.return_value = ["aws_vpc", "aws_subnet"]
+
+    aft_vpc = CloudResource(
+        resource_id="vpc-aft-management",
+        resource_type="aws_vpc",
+        tags={"managed-by": "AFT"},
+    )
+    user_vpc = CloudResource(
+        resource_id="vpc-user-app",
+        resource_type="aws_vpc",
+        tags={"managed-by": "User"},
+    )
+    default_subnet = CloudResource(
+        resource_id="subnet-default-1",
+        resource_type="aws_subnet",
+        tags={"Name": "default-subnet-a"},
+    )
+    app_subnet = CloudResource(
+        resource_id="subnet-app-1",
+        resource_type="aws_subnet",
+        tags={"Name": "app-subnet-a"},
+    )
+
+    def list_side_effect(rtype: str) -> list[CloudResource]:
+        if rtype == "aws_vpc":
+            return [aft_vpc, user_vpc]
+        if rtype == "aws_subnet":
+            return [default_subnet, app_subnet]
+        return []
+
+    mock_provider.list_resources.side_effect = list_side_effect
+
+    filters = ScanFilters(
+        exclude_tags={"managed-by": "AFT"},
+        exclude_patterns=["*default*"],
+    )
+
+    engine = DiscoveryEngine(provider=mock_provider, filters=filters)
+    result = engine.discover(show_progress=False)
+
+    # aft_vpc (excluded by tag) and default_subnet (excluded by pattern) must be omitted
+    assert result.total_resources == 2
+    assert len(result.resources_by_type["aws_vpc"]) == 1
+    assert result.resources_by_type["aws_vpc"][0].resource_id == "vpc-user-app"
+    assert len(result.resources_by_type["aws_subnet"]) == 1
+    assert result.resources_by_type["aws_subnet"][0].resource_id == "subnet-app-1"

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from driftsentry.core.config import ScanFilters
+from driftsentry.core.filter import is_resource_excluded, is_state_resource_excluded
+from driftsentry.core.models import CloudResource, ResourceState
+
+
+def test_is_resource_excluded_empty_filters() -> None:
+    res = CloudResource(
+        resource_id="vpc-123",
+        resource_type="aws_vpc",
+        tags={"Name": "main"},
+    )
+    assert not is_resource_excluded(res, None)
+    assert not is_resource_excluded(res, ScanFilters())
+
+
+def test_is_resource_excluded_tag_exact_and_list() -> None:
+    filters = ScanFilters(
+        exclude_tags={
+            "managed-by": ["AFT", "ControlTower"],
+            "Environment": "baseline",
+        }
+    )
+
+    aft_res = CloudResource(
+        resource_id="vpc-1",
+        resource_type="aws_vpc",
+        tags={"Managed-By": "aft"},  # case-insensitive key and value
+    )
+    assert is_resource_excluded(aft_res, filters)
+
+    baseline_res = CloudResource(
+        resource_id="sg-1",
+        resource_type="aws_security_group",
+        tags={"environment": "baseline"},
+    )
+    assert is_resource_excluded(baseline_res, filters)
+
+    user_res = CloudResource(
+        resource_id="vpc-2",
+        resource_type="aws_vpc",
+        tags={"Managed-By": "Terraform", "Environment": "production"},
+    )
+    assert not is_resource_excluded(user_res, filters)
+
+
+def test_is_resource_excluded_tag_wildcard() -> None:
+    filters = ScanFilters(exclude_tags={"CreatedByAFT": "*"})
+
+    res = CloudResource(
+        resource_id="subnet-1",
+        resource_type="aws_subnet",
+        tags={"createdbyaft": "true"},
+    )
+    assert is_resource_excluded(res, filters)
+
+    other = CloudResource(
+        resource_id="subnet-2",
+        resource_type="aws_subnet",
+        tags={"CreatedBy": "User"},
+    )
+    assert not is_resource_excluded(other, filters)
+
+
+def test_is_resource_excluded_pattern_matching() -> None:
+    filters = ScanFilters(
+        exclude_patterns=[
+            "*aft*",
+            "vpc-default*",
+            "arn:aws:iam::*:role/aws-service-role/*",
+        ]
+    )
+
+    # Match by ID
+    res1 = CloudResource(
+        resource_id="vpc-default-12345",
+        resource_type="aws_vpc",
+    )
+    assert is_resource_excluded(res1, filters)
+
+    # Match by Name tag
+    res2 = CloudResource(
+        resource_id="vpc-999",
+        resource_type="aws_vpc",
+        tags={"Name": "my-aft-management-vpc"},
+    )
+    assert is_resource_excluded(res2, filters)
+
+    # Match by ARN
+    res3 = CloudResource(
+        resource_id="role-1",
+        resource_type="aws_iam_role",
+        arn="arn:aws:iam::123456789012:role/aws-service-role/s3.amazonaws.com/AWSServiceRoleForS3",
+    )
+    assert is_resource_excluded(res3, filters)
+
+    # Match by attribute name
+    res4 = CloudResource(
+        resource_id="sg-123",
+        resource_type="aws_security_group",
+        attributes={"name": "aft-account-customizations-sg"},
+    )
+    assert is_resource_excluded(res4, filters)
+
+    # Non-matching user resource
+    user_res = CloudResource(
+        resource_id="vpc-0987654321",
+        resource_type="aws_vpc",
+        tags={"Name": "customer-app-vpc"},
+    )
+    assert not is_resource_excluded(user_res, filters)
+
+
+def test_is_resource_excluded_regex_pattern() -> None:
+    filters = ScanFilters(exclude_patterns=["re:^sg-[0-9a-f]{4}$"])
+
+    matching = CloudResource(
+        resource_id="sg-abcd",
+        resource_type="aws_security_group",
+    )
+    assert is_resource_excluded(matching, filters)
+
+    not_matching = CloudResource(
+        resource_id="sg-abcdef123456",
+        resource_type="aws_security_group",
+    )
+    assert not is_resource_excluded(not_matching, filters)
+
+
+def test_is_state_resource_excluded() -> None:
+    filters = ScanFilters(
+        exclude_tags={"managed-by": "AFT"},
+        exclude_patterns=["*default*"],
+    )
+
+    state1 = ResourceState(
+        address="aws_vpc.default",
+        resource_type="aws_vpc",
+        resource_name="default",
+        provider="aws",
+    )
+    assert is_state_resource_excluded(state1, filters)
+
+    state2 = ResourceState(
+        address="aws_subnet.app",
+        resource_type="aws_subnet",
+        resource_name="app",
+        provider="aws",
+        attributes={"tags": {"managed-by": "AFT"}},
+    )
+    assert is_state_resource_excluded(state2, filters)
+
+    state3 = ResourceState(
+        address="aws_instance.web",
+        resource_type="aws_instance",
+        resource_name="web",
+        provider="aws",
+        attributes={"tags": {"Environment": "prod"}},
+    )
+    assert not is_state_resource_excluded(state3, filters)

--- a/tests/unit/test_scanner.py
+++ b/tests/unit/test_scanner.py
@@ -153,3 +153,94 @@ def test_scanner_does_not_mark_failed_cloud_scan_as_deleted(
 
     assert result.deleted_count == 0
     assert result.errors == ["Error scanning aws_instance: AWS unavailable"]
+
+
+def test_scanner_resource_exclusion_filters() -> None:
+    """Test DriftScanner suppresses drift for resources matching exclude_tags and exclude_patterns."""
+    # 1. State resources: one normal user resource, one AFT baseline resource
+    user_state = ResourceState(
+        address="aws_vpc.user_vpc",
+        resource_type="aws_vpc",
+        resource_name="user_vpc",
+        resource_id="vpc-user-1",
+        provider="aws",
+        attributes={"id": "vpc-user-1", "cidr_block": "10.0.0.0/16"},
+    )
+    aft_baseline_state = ResourceState(
+        address="aws_vpc.aft_baseline",
+        resource_type="aws_vpc",
+        resource_name="aft_baseline",
+        resource_id="vpc-aft-base",
+        provider="aws",
+        attributes={
+            "id": "vpc-aft-base",
+            "cidr_block": "192.168.0.0/16",
+            "tags": {"managed-by": "AFT"},
+        },
+    )
+
+    # 2. Cloud resources:
+    # - user_vpc (drifted CIDR)
+    # - aft_baseline (present in cloud with AFT tag)
+    # - unmanaged_aft_sg (unmanaged in cloud, tagged AFT)
+    # - unmanaged_default_vpc (unmanaged in cloud, named default)
+    # - unmanaged_user_bucket (unmanaged in cloud, user created)
+    cloud_resources = {
+        "aws_vpc": [
+            CloudResource(
+                resource_id="vpc-user-1",
+                resource_type="aws_vpc",
+                attributes={"id": "vpc-user-1", "cidr_block": "10.0.0.0/24"},
+                tags={"managed-by": "User"},
+            ),
+            CloudResource(
+                resource_id="vpc-aft-base",
+                resource_type="aws_vpc",
+                attributes={"id": "vpc-aft-base", "cidr_block": "192.168.0.0/24"},
+                tags={"managed-by": "AFT"},
+            ),
+            CloudResource(
+                resource_id="vpc-default",
+                resource_type="aws_vpc",
+                attributes={"id": "vpc-default"},
+                tags={"Name": "default-vpc"},
+            ),
+        ],
+        "aws_security_group": [
+            CloudResource(
+                resource_id="sg-aft-mgmt",
+                resource_type="aws_security_group",
+                attributes={"name": "aft-management-sg"},
+                tags={"managed-by": "AFT"},
+            ),
+            CloudResource(
+                resource_id="sg-user-shadow",
+                resource_type="aws_security_group",
+                attributes={"name": "shadow-sg"},
+                tags={"Environment": "user-test"},
+            ),
+        ],
+    }
+
+    config = DriftSentryConfig()
+    config.attribution.enabled = False
+    config.filters.exclude_tags = {"managed-by": ["AFT", "ControlTower"]}
+    config.filters.exclude_patterns = ["*default*", "*aft*"]
+
+    state_reader = MockStateReader([user_state, aft_baseline_state])
+    cloud_provider = MockCloudProvider(cloud_resources)
+
+    scanner = DriftScanner(config, state_reader, cloud_provider)
+    result = scanner.scan(show_progress=False)
+
+    # Verified drift items should ONLY contain:
+    # 1. aws_vpc.user_vpc (CHANGED: CIDR diff)
+    # 2. sg-user-shadow (UNMANAGED)
+    # All AFT and default resources must be excluded!
+    addresses = [item.resource_address for item in result.drift_items]
+    assert "aws_vpc.user_vpc" in addresses
+    assert any("sg-user-shadow" in addr for addr in addresses)
+    assert "aws_vpc.aft_baseline" not in addresses
+    assert not any("aft" in addr.lower() for addr in addresses)
+    assert not any("default" in addr.lower() for addr in addresses)
+    assert len(result.drift_items) == 2


### PR DESCRIPTION
## Summary

Adds granular resource exclusion filtering by tags and identifier patterns to `ScanFilters`. This enables operators to exclude account vending baseline infrastructure (such as AWS Control Tower or Account Factory for Terraform - AFT) across both `driftsentry scan` and `driftsentry discover`.

### Key Changes
- **Configuration:** Added `exclude_tags` (dict supporting string, list of strings, and `*` wildcard) and `exclude_patterns` (list of glob/regex patterns) to `ScanFilters` in `src/driftsentry/core/config.py`.
- **Matching Engine:** Created `is_resource_excluded` and `is_state_resource_excluded` in `src/driftsentry/core/filter.py` evaluating tag keys/values (case-insensitive) and identifier glob patterns against resource ID, Name tag, attributes, and ARN.
- **DriftScanner Integration:** In `src/driftsentry/core/scanner.py`, filtered live cloud resources during cloud scan, suppressed drift for excluded state resources, and omitted unmanaged detection for excluded cloud resources.
- **DiscoveryEngine Integration:** In `src/driftsentry/discovery/engine.py` and `src/driftsentry/cli/discover.py`, passed `config.filters` to filter discovered cloud inventory.
- **Documentation:** Updated `.driftsentry.yaml.example` and `docs/configuration.md` with schema tables and AFT baseline exclusion examples.
- **Testing:** Added 10 new unit tests across `test_filters.py`, `test_config.py`, `test_discover.py`, and `test_scanner.py` (144/144 tests passing, 100% pass rate).